### PR TITLE
Change the Dockerfile to only rely on the openjdk8 image

### DIFF
--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -1,19 +1,53 @@
-FROM jenkins/jenkins:alpine
+FROM openjdk:8-jre-alpine
 
-USER root
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+ARG http_port=8080
+ARG agent_port=50000
 
-# Add the system dependencies for running a basic Jenkins Evergreen instance
-RUN apk add --no-cache \
-        supervisor \
-        nodejs
-
+ENV JENKINS_HOME /var/jenkins_home
+ENV JENKINS_AGENT_PORT ${agent_port}
 ENV EVERGREEN_ENDPOINT=http://127.0.0.1:9292
+
+# Jenkins home directory is a volume, so configuration and build history
+# can be persisted and survive image upgrades
+VOLUME /var/jenkins_home
+
+# for main web interface:
+EXPOSE ${http_port}
+# will be used by attached agents:
+EXPOSE ${agent_port}
+
+
+#######################
+## Construct the image
+#######################
+
+# Add the system dependencies for running Jenkins effectively
+#
+# The only dependencies for Jenkins Essentials are:
+#   * supervisor
+#   * nodejs
+RUN apk add --no-cache git \
+                        openssh-client \
+                        unzip \
+                        bash \
+                        supervisor \
+                        nodejs
+
+# Jenkins is run with user `jenkins`, uid = 1000
+# If you bind mount a volume from the host or a data container,
+# ensure you use the same uid
+RUN addgroup -g ${gid} ${group} \
+    && adduser -h "$JENKINS_HOME" -u ${uid} -G ${group} -s /bin/bash -D ${user}
+
 
 # Prepare the evergreen-client configuration
 RUN mkdir -p /evergreen
 COPY client /evergreen/client
 COPY essentials.yaml /evergreen
-
 
 # Ensure the supervisord configuration is copied and executed by default such
 # that the Jenkins and evergreen-client processes both execute properly


### PR DESCRIPTION
This corresponds with jenkinsci/jep#57 and assumes that the evergreen-client,
when it boots, is going to be responsible for downloading the latest and
greatest Jenkins Essentials