### PR TITLE
Add simple test for container + fix basics so that Jenkins can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG agent_port=50000
 ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_AGENT_PORT ${agent_port}
 ENV EVERGREEN_ENDPOINT=http://127.0.0.1:9292
+ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_OPTS -Djava.awt.headless=true
 # Jenkins home directory is a volume, so configuration and build history
@@ -21,6 +22,7 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
+RUN mkdir -p /usr/share/jenkins/ref/init.groovy.d
 
 #######################
 ## Construct the image

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ EXPOSE ${agent_port}
 RUN mkdir -p /usr/local/bin
 COPY build/jenkins.sh /usr/local/bin/
 COPY build/jenkins-support /usr/local/bin/
+COPY shim-startup-wrapper.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/shim-startup-wrapper.sh
 
 # Add the system dependencies for running Jenkins effectively
 #
@@ -40,6 +42,7 @@ RUN apk add --no-cache git \
                         bash \
                         supervisor \
                         nodejs
+                        curl # FIXME curl is added for shim-startup-wrapper.sh, remove it when the client downloads the WAR
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
@@ -52,6 +55,9 @@ RUN addgroup -g ${gid} ${group} \
 RUN mkdir -p /evergreen
 COPY client /evergreen/client
 COPY essentials.yaml /evergreen
+
+# FIXME REMOVE (to ease iteration/speed just for now), see also shim-startup-wrapper.sh
+RUN wget --quiet http://mirrors.jenkins.io/war-stable/latest/jenkins.war -O /usr/share/jenkins/jenkins.war
 
 # Ensure the supervisord configuration is copied and executed by default such
 # that the Jenkins and evergreen-client processes both execute properly

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_AGENT_PORT ${agent_port}
 ENV EVERGREEN_ENDPOINT=http://127.0.0.1:9292
 
+ENV JAVA_OPTS -Djava.awt.headless=true
 # Jenkins home directory is a volume, so configuration and build history
 # can be persisted and survive image upgrades
 VOLUME ${JENKINS_HOME}
@@ -41,7 +42,8 @@ RUN apk add --no-cache git \
                         unzip \
                         bash \
                         supervisor \
-                        nodejs
+                        nodejs \
+                        ttf-dejavu \
                         curl # FIXME curl is added for shim-startup-wrapper.sh, remove it when the client downloads the WAR
 
 # Jenkins is run with user `jenkins`, uid = 1000

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,13 @@ pipeline {
                 sh 'make container'
             }
         }
+
+        stage('Test container') {
+            steps {
+                sh './test-container.sh'
+            }
+        }
+
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ all: check container
 check:
 	$(MAKE) -C client $@
 	$(MAKE) -C services $@
+	./test-container.sh
 
 container-prereqs: build/jenkins-support build/jenkins.sh
 
@@ -26,7 +27,6 @@ clean:
 	$(MAKE) -C client $@
 	$(MAKE) -C services $@
 #################
-
 
 update-center.json:
 	curl -sSL https://updates.jenkins.io/current/update-center.actual.json > update-center.json

--- a/shim-startup-wrapper.sh
+++ b/shim-startup-wrapper.sh
@@ -27,4 +27,4 @@ else
   download_war
 fi
 
-jenkins.sh $@
+exec jenkins.sh $@

--- a/shim-startup-wrapper.sh
+++ b/shim-startup-wrapper.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+echo "*TEMPORARY* script to download Jenkins.war, to let us iterate while the client isn't yet able to do it in the right way."
+
+TARGET=/usr/share/jenkins/jenkins.war
+SOURCE=http://mirrors.jenkins.io/war-stable/latest/jenkins.war
+SHA_SOURCE=${SOURCE}.sha256
+
+download_war() {
+  echo "Downloading $SOURCE into $TARGET"
+  wget $SOURCE -O $TARGET
+}
+
+if test -f $TARGET; then
+  echo "$TARGET already exists, checking checksum."
+  cd $( dirname $TARGET)
+  curl -s $SHA_SOURCE > /tmp/checksum_file
+  if sha256sum /tmp/checksum_file > /dev/null ; then
+    echo "File has the right checksum, no download."
+  else
+    echo "WRONG checksum, need to download again."
+    download_war
+  fi
+
+else
+  echo "No WAR file found, downloading."
+  download_war
+fi
+
+jenkins.sh $@

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -8,7 +8,7 @@ port=:9001
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:jenkins]
-command=/usr/local/bin/jenkins.sh
+command=/usr/local/bin/shim-startup-wrapper.sh
 directory=/var/jenkins_home
 environment=JENKINS_HOME=/var/jenkins_home
 stdout_logfile=/dev/stdout

--- a/test-container.sh
+++ b/test-container.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+### FUNCTIONS / SETUP
+
+# will use the local build, but could also be used to test a remote image
+# TODO: pass an image:tag param?
+
+C_NAME=evergreen-testing-$RANDOM
+exit_code=0
+
+cleanup () {
+  exit_code=$?
+  docker kill $C_NAME 2>/dev/null >/dev/null || echo "Already dead."
+  docker rm   $C_NAME 2>/dev/null >/dev/null || echo "Already removed."
+  exit $exit_code
+}
+
+trap cleanup EXIT ERR INT TERM
+
+find_free_port() {
+  candidate_port=$(( ( $RANDOM % ( 65535 - 1024 ) )  + 1024 ))
+  used_ports=$( netstat -ntap 2> /dev/null | tr -s ' ' | cut -d ' ' -f4 | grep ':' | awk -F ":" '{print $NF}' )
+  echo $candidate_port
+}
+
+### HERE STARTS THE REAL MEAT
+
+TEST_PORT=$(find_free_port)
+echo "Using the port $TEST_PORT"
+
+# TODO use docker-compose to use network and avoid all this
+echo "Start container under test and wait a bit for its startup:"
+docker run --name $C_NAME -p $TEST_PORT:8080 -d jenkins/evergreen:latest
+sleep 10
+
+echo "Connect to Jenkins"
+curl --silent http://localhost:$TEST_PORT > output.html
+
+echo "Check content"
+grep "Authentication required" output.html > /dev/null


### PR DESCRIPTION
Jenkins should be available after startup.

I have the changes locally that makes this work, though not clean (at all) yet:

```
evergreen $ ./test-container.sh
Using the port 5901
Start container under test and wait a bit for its startup:
b194fb14217a1174a43d888d70942328161419e21fdaaeee2688a9fc967a05d7
Connect to Jenkins
Check content
```

cc @rtyler 