### PR TITLE
Update the Jenkinsfile to only publish the docker container in trusted.ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,20 @@ pipeline {
             }
         }
 
+        stage('Publish jenkins/evergreen') {
+            when {
+                expression { infra.isTrusted() }
+            }
+
+            steps {
+                withCredentials([[$class: 'ZipFileBinding',
+                           credentialsId: 'jenkins-dockerhub',
+                                variable: 'DOCKER_CONFIG']]) {
+                    sh 'make publish'
+                }
+            }
+        }
+
     }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ container-check: shunit2 ./tests/tests.sh container
 container: container-prereqs Dockerfile supervisord.conf fetch-versions
 	docker build -t ${JENKINS_CONTAINER}:latest .
 
+publish: container
+	docker push ${JENKINS_CONTAINER}:latest
+
 fetch-versions: essentials.yaml ./scripts/update-essentials update-center.json
 	$(RUBY) ./scripts/update-essentials essentials.yaml update-center.json
 


### PR DESCRIPTION
This will allow us to start populating jenkins/evergreen with our changes

Fixes [JENKINS-49842](https://issues.jenkins-ci.org/browse/JENKINS-49842)