### PR TITLE
[JENKINS-49861] Disable master executors by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ check: lint
 	$(MAKE) -C services $@
 	$(MAKE) container-check
 
-container-prereqs: build/jenkins-support build/jenkins.sh scripts/shim-startup-wrapper.sh
+container-prereqs: build/jenkins-support build/jenkins.sh build/install-plugins.sh scripts/shim-startup-wrapper.sh
 
 container-check: shunit2 ./tests/tests.sh container
 	./tests/tests.sh
@@ -42,6 +42,11 @@ build/jenkins.sh:
 build/jenkins-support:
 	mkdir -p build
 	curl -sSL $(SCRIPTS_URL)/jenkins-support > $@
+	chmod +x $@
+
+build/install-plugins.sh:
+	mkdir -p build
+	curl -sSL $(SCRIPTS_URL)/install-plugins.sh > $@
 	chmod +x $@
 
 shunit2:

--- a/essentials.yaml
+++ b/essentials.yaml
@@ -10,9 +10,12 @@ spec:
     # version: 1.0
 
   plugins:
+    - groupId: 'org.jenkins-ci.plugins'
+      artifactId: 'configuration-as-code'
+      version: '0.1-alpha'
+
     - groupId: 'io.jenkins.blueocean'
       artifactId: 'blueocean'
-      # ref: 'master'
       version: '1.4.2'
 
     - groupId: 'org.jenkins-ci.plugins'

--- a/jenkins-configuration.yaml
+++ b/jenkins-configuration.yaml
@@ -1,0 +1,3 @@
+jenkins:
+  systemMessage: "Welcome to Jenkins Essentials!"
+  numExecutors: 0

--- a/scripts/shim-startup-wrapper.sh
+++ b/scripts/shim-startup-wrapper.sh
@@ -27,4 +27,10 @@ else
   download_war
 fi
 
+# FIXME: Only hardcoded to install casc,
+# not following essentials.yaml declaration
+# On purpose to make the startup faster
+# anyway the whole file is a *shim* :P
+install-plugins.sh configuration-as-code:experimental
+
 exec jenkins.sh $@

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -30,4 +30,10 @@ test_docker_CLI_available() {
   assertEquals "expected message about daemon unavailable" 0 $?
 }
 
+test_no_executor() {
+  numExecutors=$( docker exec $container_under_test cat /var/jenkins_home/config.xml | \
+      grep '<numExecutors>0</numExecutors>' | tr -d ' ' )
+  assertEquals "<numExecutors>0</numExecutors>" "$numExecutors"
+}
+
 . ./shunit2/shunit2

--- a/tests/utilities
+++ b/tests/utilities
@@ -1,6 +1,17 @@
 container_under_test_prefix=evergreen-testing
 container_under_test=$container_under_test_prefix-$RANDOM
 
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+warn() {
+  echo -e "$RED**** $@ ****$NC"
+}
+
+info() {
+  echo "$@"
+}
+
 cleanup () {
   echo
   echo -n "Cleaning up... "
@@ -23,23 +34,27 @@ setup_container_under_test() {
   TEST_PORT=$(find_free_port)
 
   # TODO use docker-compose to use network and avoid all this?
-  echo "Start container under test (port=$TEST_PORT) and wait a bit for its startup:"
+  info "Start container under test (port=$TEST_PORT) and wait a bit for its startup:"
   docker run --rm --name $container_under_test -p $TEST_PORT:8080 -d jenkins/evergreen:latest
   sleep 5
 
-  max_attempts=10
+  # FIXME: have to wait pretty long because plugin installations
+  # Possibly we'll want a special mode to accelerate testing, maybe by downloading plugins
+  # from a local cache by overriding JENKINS_UC?
+  max_attempts=20
+  cur_attempts=0
   while true
   do
+    cur_attempts=$(( cur_attempts + 1 ))
     if ( docker logs $container_under_test | grep "Jenkins is fully up and running" ); then
-      echo "Jenkins has started."
+      info "Jenkins has started."
       break;
-    elif (( $max_attempts < 1 )); then
-      echo "Jenkins did not start before timeout. Tests are expected to fail."
+    elif (( $cur_attempts > $max_attempts )); then
+      warn "Jenkins did not start before timeout. Tests are expected to fail."
       break;
     else
-      echo "Waiting for Jenkins startup a bit more..."
+      info "Waiting for Jenkins startup a bit more... ($cur_attempts/$max_attempts attempts) "
     fi
     sleep 3
-    max_attempts=$(( max_attempts -1 ))
   done
 }


### PR DESCRIPTION
Also introduces [configuration-as-code plugin](https://github.com/jenkinsci/configuration-as-code-plugin) first usage for this purpose.

For people wanting to try this:
```
make container-check
```