### PR TITLE
Build and use master branch of CasC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,3 +84,5 @@ ENV CASC_JENKINS_CONFIG=$JENKINS_HOME/jenkins.yaml
 # that the Jenkins and evergreen-client processes both execute properly
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 CMD /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+
+COPY configuration-as-code.hpi /usr/share/jenkins/ref/plugins/configuration-as-code.hpi

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ COPY essentials.yaml /evergreen
 
 # FIXME (?): what if the end users touches the config value?
 # as is, we'll override it.
+COPY build/configuration-as-code/target/configuration-as-code.hpi /usr/share/jenkins/ref/plugins/configuration-as-code.hpi
 COPY jenkins-configuration.yaml /usr/share/jenkins/ref/jenkins.yaml
 ENV CASC_JENKINS_CONFIG=$JENKINS_HOME/jenkins.yaml
 
@@ -84,5 +85,3 @@ ENV CASC_JENKINS_CONFIG=$JENKINS_HOME/jenkins.yaml
 # that the Jenkins and evergreen-client processes both execute properly
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 CMD /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
-
-COPY configuration-as-code.hpi /usr/share/jenkins/ref/plugins/configuration-as-code.hpi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,5 @@
 pipeline {
     agent { label 'linux' }
-    tools {
-      maven 'mvn'
-      jdk 'jdk8'
-    }
 
     stages {
         stage('Prepare Workspace') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 pipeline {
     agent { label 'linux' }
+    tools {
+      maven 'mvn'
+      jdk 'jdk8'
+    }
 
     stages {
         stage('Prepare Workspace') {
@@ -28,7 +32,7 @@ pipeline {
 
         stage('Build jenkins/evergreen') {
             steps {
-                sh 'make container'
+              sh 'make container'
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build/configuration-as-code:
 	git clone https://github.com/jenkinsci/configuration-as-code-plugin.git build/configuration-as-code
 
 build/configuration-as-code/target/configuration-as-code.hpi: build/configuration-as-code
-	cd build/configuration-as-code && mvn clean package -DskipTests
+	./tools/mvn --file build/configuration-as-code clean package -DskipTests
 
 shunit2:
 	git clone https://github.com/kward/shunit2

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check: lint
 	$(MAKE) -C services $@
 	$(MAKE) container-check
 
-container-prereqs: build/jenkins-support build/jenkins.sh build/install-plugins.sh scripts/shim-startup-wrapper.sh
+container-prereqs: build/jenkins-support build/jenkins.sh build/install-plugins.sh scripts/shim-startup-wrapper.sh build/configuration-as-code/target/configuration-as-code.hpi
 
 container-check: shunit2 ./tests/tests.sh container
 	./tests/tests.sh
@@ -34,6 +34,8 @@ clean:
 	rm -f update-center.json
 	$(MAKE) -C client $@
 	$(MAKE) -C services $@
+	rm -rf build/configuration-as-code/target
+
 #################
 
 build/jenkins.sh:
@@ -50,6 +52,12 @@ build/install-plugins.sh:
 	mkdir -p build
 	curl -sSL $(SCRIPTS_URL)/install-plugins.sh > $@
 	chmod +x $@
+
+build/configuration-as-code:
+	git clone https://github.com/jenkinsci/configuration-as-code-plugin.git build/configuration-as-code
+
+build/configuration-as-code/target/configuration-as-code.hpi: build/configuration-as-code
+	cd build/configuration-as-code && mvn clean package -DskipTests
 
 shunit2:
 	git clone https://github.com/kward/shunit2

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -16,7 +16,7 @@ oneTimeTearDown() {
 }
 
 test_smoke() {
-  curl --silent "http://localhost:$TEST_PORT > /dev/null"
+  curl --silent "http://localhost:$TEST_PORT" > /dev/null
   assertEquals "Bad exit" 0 $?
 }
 

--- a/tools/mvn
+++ b/tools/mvn
@@ -1,0 +1,8 @@
+#!/bin/sh -xe
+
+exec docker run --rm \
+    -v "$(pwd)":/usr/src/mymaven \
+    -w /usr/src/mymaven \
+    -v ~/.m2:/var/maven/.m2 \
+    --user $( id -u ) -e MAVEN_CONFIG=/var/maven/.m2 \
+    maven:3.5.3-jdk-8 mvn -Duser.home=/var/maven $@


### PR DESCRIPTION
(Note: not sure that `mvn` and `git clone` raw command calls are going to work in CI. Let's see.)

CasC being still in very early phase, using `master` will help
us benefit immediately from improvements or fixes filed upstream (like https://github.com/jenkinsci/configuration-as-code-plugin/pull/152 for example).

This being too the model we target in the long term, this is not
probably not that weird to try it (though the delivery model will
obviously be very different)