### PR TITLE
Force jest to exit once tests complete on the server

### DIFF
--- a/services/Makefile
+++ b/services/Makefile
@@ -14,6 +14,9 @@ lint: depends
 unit:
 	$(COMPOSE) run -e NODE_ENV=test --rm node npm run jest
 
+watch:
+	$(COMPOSE) run -e NODE_ENV=test --rm node jest --watchAll
+
 
 depends: package.json
 	# Checking to see if the directory exists because npm install updates the

--- a/services/package.json
+++ b/services/package.json
@@ -22,7 +22,7 @@
     "test": "npm run eslint && npm run jest",
     "eslint": "eslint src/. test/. --config .eslintrc.json",
     "start": "node src/",
-    "jest": "jest -w 1"
+    "jest": "jest -i --forceExit"
   },
   "dependencies": {
     "@feathersjs/authentication": "^2.1.3",

--- a/services/package.json
+++ b/services/package.json
@@ -22,7 +22,7 @@
     "test": "npm run eslint && npm run jest",
     "eslint": "eslint src/. test/. --config .eslintrc.json",
     "start": "node src/",
-    "jest": "jest"
+    "jest": "jest -w 1"
   },
   "dependencies": {
     "@feathersjs/authentication": "^2.1.3",


### PR DESCRIPTION
From the jest docs:

    Note: This feature is an escape-hatch. If Jest doesn't exit at the end of a
    test run, it means external resources are still being held on to or timers are
    still pending in your code. It is advised to tear down external resources after
    each test to make sure Jest can shut down cleanly.

As far as I can tell, the sequelize client is constructing some additional
timers or promises and resulting the jest only hanging in the cases of the
following invocations:

 * jest -i
 * jest -w 1

I've burned a couple hours trying to figure out whether a real resource leak is
happening here, and cannot spot anything, so let's go with this for now.