### PR TITLE
[JENKINS-49805] Use a logging.properties file to put Jenkins logs under $JENKINS_VAR/logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ ENV JAVA_OPTS=\
 "-Djava.awt.headless=true "\
 "-Djenkins.model.Jenkins.WORKSPACES_DIR=${JENKINS_VAR}/\${ITEM_FULL_NAME}/workspace "\
 "-Djenkins.model.Jenkins.BUILDS_DIR=$JENKINS_VAR/\${ITEM_FULL_NAME}/builds "\
-"-Dhudson.triggers.SafeTimerTask.logsTargetDir=$JENKINS_VAR/logs"
+"-Dhudson.triggers.SafeTimerTask.logsTargetDir=$JENKINS_VAR/logs "\
+"-Djava.util.logging.config.file=$EVERGREEN_HOME/logging.properties "
 
 ENV JENKINS_OPTS=\
 "--webroot=${JENKINS_VAR}/war "\
@@ -30,7 +31,9 @@ ENV JENKINS_OPTS=\
 RUN mkdir -p /usr/share/jenkins/ref/ && \
     mkdir ${EVERGREEN_HOME} && \
     mkdir ${EVERGREEN_HOME}/jenkins/ && \
-    mkdir ${JENKINS_HOME}
+    mkdir ${JENKINS_HOME} && \
+    mkdir ${JENKINS_VAR} && \
+    mkdir ${JENKINS_VAR}/logs
 
 # for main web interface:
 EXPOSE ${http_port}
@@ -63,6 +66,8 @@ RUN cd /tmp && \
     mv docker/* /usr/local/bin && \
     rmdir docker && \
     rm docker.tar.gz
+
+COPY logging.properties $EVERGREEN_HOME/logging.properties
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,15 @@
+.level=INFO
+handlers=java.util.logging.ConsoleHandler,java.util.logging.FileHandler
+
+java.util.logging.SimpleFormatter.format=[%4$s][%1$tF %1$tT] %5$s (from %2$s)%6$s%n
+
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+
+java.util.logging.FileHandler.level=INFO
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.encoding=UTF-8
+java.util.logging.FileHandler.limit=10000000
+java.util.logging.FileHandler.count=5
+# FIXME: Ideally, we should find a way to use $JENKINS_VAR below instead of the hardcoded value
+java.util.logging.FileHandler.pattern=/evergreen/jenkins/var/logs/jenkins.log.%g

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -76,4 +76,11 @@ test_logs_are_not_under_jenkins_home() {
   assertEquals "ls: /evergreen/jenkins/home/logs: No such file or directory" "$result"
 }
 
+test_jenkins_logs_is_found_on_disk() {
+  # shellcheck disable=SC2016
+  result=$( docker exec $container_under_test bash -c 'cat $JENKINS_VAR/logs/jenkins.log.0' | \
+            grep 'Jenkins is fully up and running' )
+  assertEquals "0" "$?"
+}
+
 . ./shunit2/shunit2


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-49805

So the main goal here is to start using a `logging.properties` file. 
I also used a rotating file logging for now while we're discussing this on the ML, to have more concrete feedback/experience on the matter.

Example of logging obtained this way:

```
[INFO][2018-04-03 14:08:15] Obtained the latest update center data file for UpdateSource default (from hudson.model.UpdateSite updateData)
[INFO][2018-04-03 14:08:15] Obtained the latest update center data file for UpdateSource default (from hudson.model.UpdateSite updateData)
[INFO][2018-04-03 14:08:16] Completed initialization (from jenkins.InitReactorRunner$1 onAttained)
[INFO][2018-04-03 14:08:16] Jenkins is fully up and running (from hudson.WebAppMain$3 run)
[INFO][2018-04-03 14:08:16] Obtained the updated data file for hudson.tasks.Maven.MavenInstaller (from hudson.model.DownloadService$Downloadable load)
[INFO][2018-04-03 14:08:16] Finished Download metadata. 7,479 ms (from hudson.model.AsyncPeriodicWork$1 run)
```

I think this would make a lot of sense for the console logging to use it, and write some JSONFormatter for outputting things in JSON for easier consumption by the client.