### PR TITLE
Add telemetry logging to disk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ COPY build/configuration-as-code/target/configuration-as-code.hpi /usr/share/jen
 COPY jenkins-configuration.yaml /usr/share/jenkins/ref/jenkins.yaml
 ENV CASC_JENKINS_CONFIG=$JENKINS_HOME/jenkins.yaml
 
+COPY build/essentials/target/essentials.hpi /usr/share/jenkins/ref/plugins/essentials.hpi
+
 RUN chown -R $user:$group $EVERGREEN_HOME
 
 # Jenkins directory is a volume, so configuration and build history

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ check: lint
 	$(MAKE) -C services $@
 	$(MAKE) container-check
 
-container-prereqs: build/jenkins-support build/jenkins.sh scripts/shim-startup-wrapper.sh build/configuration-as-code/target/configuration-as-code.hpi
+container-prereqs: build/jenkins-support build/jenkins.sh scripts/shim-startup-wrapper.sh build/configuration-as-code/target/configuration-as-code.hpi build/essentials/target/essentials.hpi
 
 container-check: shunit2 ./tests/tests.sh container
 	./tests/tests.sh
@@ -44,6 +44,7 @@ clean:
 	$(MAKE) -C services $@
 	rm -f build/docker-compose
 	rm -rf build/configuration-as-code/target
+	rm -rf build/essentials/target
 
 #################
 
@@ -62,6 +63,12 @@ build/configuration-as-code:
 
 build/configuration-as-code/target/configuration-as-code.hpi: build/configuration-as-code
 	./tools/mvn --file build/configuration-as-code clean package -DskipTests
+
+build/essentials:
+	git clone --depth 1 https://github.com/batmat/essentials-plugin.git build/essentials
+
+build/essentials/target/essentials.hpi: build/essentials
+	./tools/mvn --file build/essentials clean package
 
 shunit2:
 	git clone --depth 1 https://github.com/kward/shunit2

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,13 @@ build/configuration-as-code:
 	git clone --depth 1 https://github.com/jenkinsci/configuration-as-code-plugin.git build/configuration-as-code
 
 build/configuration-as-code/target/configuration-as-code.hpi: build/configuration-as-code
-	./tools/mvn --file build/configuration-as-code clean package -DskipTests
+	./tools/mvn --batch-mode --file build/configuration-as-code clean package -DskipTests
 
 build/essentials:
 	git clone --depth 1 https://github.com/batmat/essentials-plugin.git build/essentials
 
 build/essentials/target/essentials.hpi: build/essentials
-	./tools/mvn --file build/essentials clean package
+	./tools/mvn --batch-mode --file build/essentials clean package
 
 shunit2:
 	git clone --depth 1 https://github.com/kward/shunit2

--- a/tools/jsonlint
+++ b/tools/jsonlint
@@ -1,0 +1,7 @@
+#!/bin/sh -xe
+
+exec docker run --rm \
+    -w ${PWD} \
+    -v ${PWD}:${PWD} \
+    -i \
+    sahsu/docker-jsonlint jsonlint $@


### PR DESCRIPTION
Filter logs ≥ `WARNING` to disk in json format.

It pushes logs under `$JENKINS_VAR/logs/essentials.log.N`, with the following format:

```json
$ cat /evergreen/jenkins/var/logs/essentials.log.0
{"timestamp":1522835507869,"level":"SEVERE","message":"I started!"}
{"timestamp":1522835504954,"level":"WARNING","message":"Created /evergreen/jenkins/var/plugins/job-dsl/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness"}
```