### PR TITLE
[JENKINS-50624] Rework the custom plugins builds system to make it easier to add/remove a plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,11 +90,10 @@ COPY essentials.yaml ${EVERGREEN_HOME}
 
 # FIXME (?): what if the end users touches the config value?
 # as is, we'll override it.
-COPY build/configuration-as-code/target/configuration-as-code.hpi /usr/share/jenkins/ref/plugins/configuration-as-code.hpi
 COPY jenkins-configuration.yaml /usr/share/jenkins/ref/jenkins.yaml
 ENV CASC_JENKINS_CONFIG=$JENKINS_HOME/jenkins.yaml
 
-COPY build/essentials/target/essentials.hpi /usr/share/jenkins/ref/plugins/essentials.hpi
+COPY build/*.hpi /usr/share/jenkins/ref/plugins/
 
 RUN chown -R $user:$group $EVERGREEN_HOME
 

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,17 @@ all: check container
 lint: essentials.yaml shunit2
 	./tools/yamllint -s ./essentials.yaml
 	./tools/shellcheck -x tests/tests.sh
-	./tools/shellcheck -x scripts/shim-startup-wrapper.sh
+	./tools/shellcheck -x scripts/*.sh
 
 check: lint
 	$(MAKE) -C client $@
 	$(MAKE) -C services $@
 	$(MAKE) container-check
 
-container-prereqs: build/jenkins-support build/jenkins.sh scripts/shim-startup-wrapper.sh build/configuration-as-code/target/configuration-as-code.hpi build/essentials/target/essentials.hpi
+container-prereqs: build/jenkins-support build/jenkins.sh scripts/shim-startup-wrapper.sh build-plugins
+
+build-plugins:
+	./scripts/build-plugins.sh
 
 container-check: shunit2 ./tests/tests.sh container
 	./tests/tests.sh
@@ -57,18 +60,6 @@ build/jenkins-support:
 	mkdir -p build
 	$(DOWNLOAD) $(SCRIPTS_URL)/jenkins-support > $@
 	chmod +x $@
-
-build/configuration-as-code:
-	git clone --depth 1 https://github.com/jenkinsci/configuration-as-code-plugin.git build/configuration-as-code
-
-build/configuration-as-code/target/configuration-as-code.hpi: build/configuration-as-code
-	./tools/mvn --batch-mode --file build/configuration-as-code clean package -DskipTests
-
-build/essentials:
-	git clone --depth 1 https://github.com/batmat/essentials-plugin.git build/essentials
-
-build/essentials/target/essentials.hpi: build/essentials
-	./tools/mvn --batch-mode --file build/essentials clean package
 
 shunit2:
 	git clone --depth 1 https://github.com/kward/shunit2

--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ build/jenkins-support:
 shunit2:
 	git clone --depth 1 https://github.com/kward/shunit2
 
-.PHONY: all check clean container container-check container-prereqs
+.PHONY: all check clean container container-check container-prereqs build-plugins

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+current_dir=$( dirname "$0" )
+build_dir=$( mkdir -p "$current_dir/../build/plugins" && cd "$current_dir/../build/plugins" && pwd )
+tools_dir=$( cd "$current_dir/../tools" && pwd )
+export PATH=$tools_dir:$PATH
+
+# shellcheck disable=SC2013
+for line in $( grep -ve '^#' "$current_dir/plugins-to-build.list" )
+do
+  cd "$build_dir"
+  org=$( echo "$line" | cut -d':' -f1 )
+  repo=$( echo "$line" | cut -d':' -f2 )
+  branch=$( echo "$line" | cut -d':' -f3 )
+
+  repo_url=https://github.com/$org/$repo.git
+  local_path=$build_dir/$repo
+
+  if [[ -d $local_path ]]; then
+    echo "$local_path already exists, nothing to do. Wipe out if you wish to update or clone again."
+  else
+    echo "Cloning $repo_url into $local_path, branch=$branch"
+    git clone --depth 1 --branch "$branch" "$repo_url" "$local_path"
+  fi
+
+  artifactId=${repo//-plugin/}
+  if [[ -f "$local_path/target/$artifactId.hpi" ]] ; then
+    echo "hpi found under $local_path, no build. Wipe out if you wish to rebuild the plugin."
+  else
+    echo "Building $local_path (without tests...)"
+    cd "$local_path"
+    mvn --batch-mode -DskipTests clean package
+  fi
+done
+
+echo "Copying HPIs"
+find "$build_dir" -maxdepth 3 -name "*.hpi" -exec cp "{}" "$build_dir/.." \;

--- a/scripts/casc-dependencies.aria
+++ b/scripts/casc-dependencies.aria
@@ -1,16 +1,25 @@
-# https://updates.jenkins.io/experimental/latest/configuration-as-code.hpi # built by us
-https://updates.jenkins.io/2.107/latest/workflow-multibranch.hpi
-https://updates.jenkins.io/2.107/latest/job-dsl.hpi
-https://updates.jenkins.io/2.107/latest/workflow-api.hpi
-https://updates.jenkins.io/2.107/latest/workflow-cps.hpi
-https://updates.jenkins.io/2.107/latest/workflow-job.hpi
-https://updates.jenkins.io/2.107/latest/workflow-scm-step.hpi
-https://updates.jenkins.io/2.107/latest/workflow-step-api.hpi
-https://updates.jenkins.io/2.107/latest/workflow-support.hpi
-https://updates.jenkins.io/2.107/latest/branch-api.hpi
-https://updates.jenkins.io/2.107/latest/cloudbees-folder.hpi
-https://updates.jenkins.io/2.107/latest/scm-api.hpi
-https://updates.jenkins.io/2.107/latest/script-security.hpi
-https://updates.jenkins.io/2.107/latest/structs.hpi
-https://updates.jenkins.io/2.107/latest/ace-editor.hpi
-https://updates.jenkins.io/2.107/latest/jquery-detached.hpi
+# CasC dependencies
+https://updates.jenkins.io/experimental/latest/configuration-as-code.hpi
+https://updates.jenkins.io/latest/workflow-multibranch.hpi
+https://updates.jenkins.io/latest/job-dsl.hpi
+https://updates.jenkins.io/latest/workflow-api.hpi
+https://updates.jenkins.io/latest/workflow-cps.hpi
+https://updates.jenkins.io/latest/workflow-job.hpi
+https://updates.jenkins.io/latest/workflow-scm-step.hpi
+https://updates.jenkins.io/latest/workflow-step-api.hpi
+https://updates.jenkins.io/latest/workflow-support.hpi
+https://updates.jenkins.io/latest/branch-api.hpi
+https://updates.jenkins.io/latest/cloudbees-folder.hpi
+https://updates.jenkins.io/latest/scm-api.hpi
+https://updates.jenkins.io/latest/script-security.hpi
+https://updates.jenkins.io/latest/structs.hpi
+https://updates.jenkins.io/latest/ace-editor.hpi
+https://updates.jenkins.io/latest/jquery-detached.hpi
+
+# Metrics plugin and dependencies
+https://updates.jenkins.io/latest/metrics.hpi
+https://updates.jenkins.io/latest/bouncycastle-api.hpi
+https://updates.jenkins.io/latest/jdk-tool.hpi
+https://updates.jenkins.io/latest/script-security.hpi
+https://updates.jenkins.io/latest/command-launcher.hpi
+https://updates.jenkins.io/latest/jackson2-api.hpi

--- a/scripts/plugins-to-build.list
+++ b/scripts/plugins-to-build.list
@@ -1,0 +1,4 @@
+# org:repo:branch
+jenkinsci:metrics-plugin:master
+jenkinsci:configuration-as-code-plugin:master
+batmat:essentials-plugin:master

--- a/scripts/shim-startup-wrapper.sh
+++ b/scripts/shim-startup-wrapper.sh
@@ -43,7 +43,6 @@ else
   download_war
 fi
 
-
 # FIXME: Only hardcoded to install casc,
 # not following essentials.yaml declaration
 # On purpose to make the startup faster
@@ -53,7 +52,18 @@ mkdir "$download_tmp"
 cd $download_tmp
 aria2c -x 4 -i /casc-dependencies.aria
 mkdir -p "$JENKINS_HOME/plugins/"
-mv ./*.hpi "$JENKINS_HOME/plugins/"
+
+custom_plugins=$( find /usr/share/jenkins/ref/plugins/ )
+for downloaded_plugin in *.hpi
+do
+  if echo "$custom_plugins" | grep "$downloaded_plugin" > /dev/null ; then
+    echo "NOT clobbering the preinstalled $downloaded_plugin with the downloaded one"
+  else
+    echo "Moving $downloaded_plugin to $JENKINS_HOME/plugins/"
+    mv "$downloaded_plugin" "$JENKINS_HOME/plugins/"
+  fi
+done
+
 rm -rf $download_tmp
 cd "$JENKINS_HOME"
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50624

So the idea is now, the `plugins-to-build.list` file contains a colon separated format that allows one to express the plugin we should build by ourselves.

```
# org:repo:branch
jenkinsci:metrics-plugin:master
jenkinsci:configuration-as-code-plugin:master
batmat:essentials-plugin:master
```

Also, then we do not need anymore to twiddle with the source file for `aria2c`. We just declare there everything need for a given plugin, then the custom/local build will be favored if present. Caveat: we might download a few plugins unnecessarily, but a plugin is generally so small it should not be an issue.