### PR TITLE
Use /instance-identity/ instead for health-checking

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -101,9 +101,15 @@ test_essentials_telemetry_logging_is_found_on_disk() {
   assertEquals "0" "$?"
 }
 
-# JENKINS-50294 Health checking
+# not used for health-checking anymore, but kept for smoke testing
 test_login_http_200() {
   status_code=$( curl --silent --output /dev/null --write-out "%{http_code}" "http://localhost:$TEST_PORT/login" )
+  assertEquals "0" "$?"
+  assertEquals "200" "$status_code"
+}
+# JENKINS-50294 Health checking
+test_instance_identity_http_200() {
+  status_code=$( curl --silent --output /dev/null --write-out "%{http_code}" "http://localhost:$TEST_PORT/instance-identity/" )
   assertEquals "0" "$?"
   assertEquals "200" "$status_code"
 }
@@ -117,7 +123,7 @@ test_metrics_health_check() {
   jsonlint < $output > /dev/null
   assertEquals "0" "$?"
 
-  # Check things are all healthy 
+  # Check things are all healthy
   result=$( jq '.[].healthy' < $output | sort -u )
   assertEquals "true" "$result"
 }


### PR DESCRIPTION
Align to https://github.com/batmat/jep/tree/6ea85ea540c341d3543fc819bf73632c0584e2a2/jep/0000 