### PR TITLE
Remove debug/verbose mode for tools

### DIFF
--- a/tools/jsonlint
+++ b/tools/jsonlint
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 exec docker run --rm \
     -w ${PWD} \

--- a/tools/mvn
+++ b/tools/mvn
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 MAVEN_REPO=~/.m2/
 mkdir -p $MAVEN_REPO/repository

--- a/tools/shellcheck
+++ b/tools/shellcheck
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 exec docker run --rm \
     -w ${PWD} \

--- a/tools/yamllint
+++ b/tools/yamllint
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 exec docker run --rm \
     -w ${PWD} \


### PR DESCRIPTION
I think we could remove this option to make things like `make lint` less verbose, and IMO more readable, also now we know those work.

Before this change:

```shell
$ make lint 
./tools/yamllint -s configuration/essentials.yaml
+ exec docker run --rm -w /home/tiste/dev/github/jenkins-infra/evergreen -v /home/tiste/dev/github/jenkins-infra/evergreen:/home/tiste/dev/github/jenkins-infra/evergreen boiyaa/yamllint -s configuration/essentials.yaml
./tools/yamllint -s configuration/jenkins-configuration.yaml
+ exec docker run --rm -w /home/tiste/dev/github/jenkins-infra/evergreen -v /home/tiste/dev/github/jenkins-infra/evergreen:/home/tiste/dev/github/jenkins-infra/evergreen boiyaa/yamllint -s configuration/jenkins-configuration.yaml
./tools/shellcheck -x tests/tests.sh
+ exec docker run --rm -w /home/tiste/dev/github/jenkins-infra/evergreen -v /home/tiste/dev/github/jenkins-infra/evergreen:/home/tiste/dev/github/jenkins-infra/evergreen koalaman/shellcheck@sha256:6dfafef2730b851e7a8bceda7f2dbef93efb709932865924cb497423b60be582 -x tests/tests.sh
./tools/shellcheck -x scripts/*.sh
+ exec docker run --rm -w /home/tiste/dev/github/jenkins-infra/evergreen -v /home/tiste/dev/github/jenkins-infra/evergreen:/home/tiste/dev/github/jenkins-infra/evergreen koalaman/shellcheck@sha256:6dfafef2730b851e7a8bceda7f2dbef93efb709932865924cb497423b60be582 -x scripts/build-plugins.sh scripts/shim-startup-wrapper.sh
```

After/with this change:

```shell
$ make lint
./tools/yamllint -s configuration/essentials.yaml
./tools/yamllint -s configuration/jenkins-configuration.yaml
./tools/shellcheck -x tests/tests.sh
./tools/shellcheck -x scripts/*.sh
```
