### PR TITLE
Check we use NPM 5+

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -128,4 +128,11 @@ test_metrics_health_check() {
   assertEquals "true" "$result"
 }
 
+# Check NPM is 5+ to make sure we do check the integrity values
+# https://github.com/jenkins-infra/evergreen/pull/60#discussion_r182666012
+test_npm_5_plus() {
+  result=$( docker exec $container_under_test npm --version )
+  assertEquals "5." "${result:0:2}"
+}
+
 . ./shunit2/shunit2


### PR DESCRIPTION
Caveat: this will fail when 6 is published.
But I feel that it's actually better this way currently: this way we **will** notice if we switch to NPM 6+ and avoid potential WUT for hours.

Thinking: should we specify versions in the `apk add ...` calls?

Followup of @wadeck question in https://github.com/jenkins-infra/evergreen/pull/60#discussion_r182666012