### PR TITLE
Adjust sysprops names to JENKINS-50164/JEP-302 merge in core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 
 ENV JAVA_OPTS=\
 "-Djava.awt.headless=true "\
-"-Djenkins.model.Jenkins.WORKSPACES_DIR=${JENKINS_VAR}/\${ITEM_FULL_NAME}/workspace "\
-"-Djenkins.model.Jenkins.BUILDS_DIR=$JENKINS_VAR/\${ITEM_FULL_NAME}/builds "\
+"-Djenkins.model.Jenkins.workspacesDir=${JENKINS_VAR}/jobs/\${ITEM_FULL_NAME}/workspace "\
+"-Djenkins.model.Jenkins.buildsDir=${JENKINS_VAR}/jobs/\${ITEM_FULL_NAME}/builds "\
 "-Dhudson.triggers.SafeTimerTask.logsTargetDir=$JENKINS_VAR/logs "\
 "-Djava.util.logging.config.file=$EVERGREEN_HOME/logging.properties "
 


### PR DESCRIPTION
Cf. https://github.com/jenkinsci/jenkins/pull/3364 which added the right sysprops to core.
Adjusting to [_JEP 302's - Segregating configuration from binaries, build data, logs, etc_ section](https://github.com/jenkinsci/jep/tree/master/jep/302#data_segregation)

Manually tested for now,
[JENKINS-50940](https://issues.jenkins-ci.org/browse/JENKINS-50940) will have the test automation for this.

I created a test called `smoke-job` manually, with the following shell step:

```sh
echo hello
touch bim$RANDOM
```

The outcome from a FS PoV:

```
bash-4.4$ ls -R home/jobs
home/jobs:
smoke-job

home/jobs/smoke-job:
config.xml       lastStable       lastSuccessful   nextBuildNumber
bash-4.4$ ls -R var/jobs/
var/jobs/:
smoke-job

var/jobs/smoke-job:
builds     workspace

var/jobs/smoke-job/builds:
2                      lastStableBuild        lastUnsuccessfulBuild
3                      lastSuccessfulBuild
lastFailedBuild        lastUnstableBuild

var/jobs/smoke-job/builds/3:
build.xml      changelog.xml  log

var/jobs/smoke-job/workspace:
bim8275
```