### PR TITLE
Properly run both client and server containers from a `make run`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres:alpine
     environment:
       - 'POSTGRES_PASSWORD=grassisevergreener'
+      # Used for psql non-interactive scripting
+      - 'PGPASSWORD=grassisevergreener'
       - 'POSTGRES_DB=evergreen_development'
 
   backend:
@@ -14,3 +16,8 @@ services:
     depends_on:
       - db
 
+  client:
+    image: jenkins/evergreen
+    build: ./
+    depends_on:
+      - backend


### PR DESCRIPTION
When executing `make run` in the root directory, everything will be checked,
built, and then run. After which bigger integration testing could operate