### PR TITLE
[JENKINS-51130] Download WAR from incrementals repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,6 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 
-# FIXME REMOVE (to ease iteration/speed just for now), see also shim-startup-wrapper.sh
-RUN wget --quiet https://ci.jenkins.io/job/Core/job/jenkins/job/master/lastSuccessfulBuild/artifact/war/target/linux-jenkins.war -O ${EVERGREEN_HOME}/jenkins.war
-RUN apk add --no-cache curl aria2 # used by shim-startup-wrapper.sh
-COPY scripts/plugins.aria /plugins.aria
-
 # Add the system dependencies for running Jenkins effectively
 #
 # The only dependencies for Jenkins Essentials are:
@@ -67,6 +62,14 @@ RUN cd /tmp && \
     mv docker/* /usr/local/bin && \
     rmdir docker && \
     rm docker.tar.gz
+
+# FIXME REMOVE when war & plugins are downloaded by client
+# see also shim-startup-wrapper.sh
+RUN apk add --no-cache curl aria2 # used by shim-startup-wrapper.sh
+COPY scripts/download-latest-war.sh /usr/local/bin/download-latest-war.sh
+RUN download-latest-war.sh
+COPY scripts/plugins.aria /plugins.aria
+# end HACK downloading shim
 
 COPY configuration/logging.properties $EVERGREEN_HOME/logging.properties
 

--- a/scripts/download-latest-war.sh
+++ b/scripts/download-latest-war.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euxo pipefail
+
+TARGET=${EVERGREEN_HOME}/jenkins.war
+SOURCE=""
+
+computeSource() {
+  # --insecure since we override CA certificates in the image
+  # not great, but the whole thing is temporary, so that's OK I think
+  latestVersion=$( curl --silent http://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-war/maven-metadata.xml | \
+                     grep latest | \
+                     sed 's#^.*<latest>\(.*\)</latest>.*#\1#' \
+                  )
+
+  [[ ! -z "$latestVersion" ]] || exit 1
+
+  echo "https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-war/$latestVersion/jenkins-war-$latestVersion.war"
+}
+
+get_checksum() {
+  checksum=$( curl --insecure --silent $SOURCE.md5 )
+  echo "$checksum  jenkins.war"
+}
+
+download_war() {
+  echo "Downloading $SOURCE into '$TARGET'"
+  wget $SOURCE -O "$TARGET"
+}
+
+SOURCE=$( computeSource )
+echo "Going to download from $SOURCE if needed"
+
+if test -f "$TARGET"; then
+  echo "$TARGET already exists, checking checksum."
+  # shellcheck disable=SC2086
+  cd "$( dirname $TARGET )"
+  get_checksum > /tmp/checksum_file
+  cat /tmp/checksum_file
+  if md5sum -c /tmp/checksum_file > /dev/null ; then
+    echo "File has the right checksum, no download."
+  else
+    echo "WRONG checksum, need to download again."
+    download_war
+  fi
+
+else
+  echo "No WAR file found, downloading."
+  download_war
+fi

--- a/scripts/download-latest-war.sh
+++ b/scripts/download-latest-war.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 TARGET=${EVERGREEN_HOME}/jenkins.war
 SOURCE=""

--- a/scripts/generate-ca-certificates
+++ b/scripts/generate-ca-certificates
@@ -11,6 +11,9 @@ for cert in $(ls /usr/share/ca-certificates/mozilla); do
         echo "mozilla/${cert}" >> $OUTPUT;
     elif  [ "${cert}" = "IdenTrust_Commercial_Root_CA_1.crt" ]; then
         echo "mozilla/${cert}" >> $OUTPUT;
+    elif  [ "${cert}" = "Go_Daddy_Root_Certificate_Authority_-_G2.crt" ]; then
+        # Incrementals https://repo.jenkins-ci.org/incrementals/
+        echo "mozilla/${cert}" >> $OUTPUT;
     else
         echo "!mozilla/${cert}" >> $OUTPUT;
     fi;

--- a/scripts/shim-startup-wrapper.sh
+++ b/scripts/shim-startup-wrapper.sh
@@ -1,47 +1,16 @@
 #!/bin/bash
 set -euo pipefail
-echo "*TEMPORARY* script to download Jenkins.war, to let us iterate while the client isn't yet able to do it in the right way."
+echo "*TEMPORARY* script to download Jenkins.war and plugins, to let us iterate while the client isn't yet able to do it in the right way."
 
-TARGET=${EVERGREEN_HOME}/jenkins.war
-export JENKINS_WAR=$TARGET
-SOURCE=https://ci.jenkins.io/job/Core/job/jenkins/job/master/lastSuccessfulBuild/artifact/war/target/linux-jenkins.war
+export JENKINS_WAR=${EVERGREEN_HOME}/jenkins.war
 
-get_checksum() {
-  checksum=$( curl --silent https://ci.jenkins.io/job/Core/job/jenkins/job/master/lastSuccessfulBuild/fingerprints/ | \
-    grep linux-jenkins.war | \
-    cut -d '"' -f 4 | \
-    cut -d / -f 3 )
-  echo "$checksum  jenkins.war"
-}
-
-download_war() {
-  echo "Downloading $SOURCE into $TARGET"
-  wget $SOURCE -O "$TARGET"
-}
+/usr/local/bin/download-latest-war.sh
 
 dump_war_metadata() {
   echo "*** WAR metadata"
   md5sum "$JENKINS_WAR"
   unzip -c "$JENKINS_WAR" META-INF/MANIFEST.MF | grep Version
 }
-
-if test -f "$TARGET"; then
-  echo "$TARGET already exists, checking checksum."
-  # shellcheck disable=SC2086
-  cd "$( dirname $TARGET )"
-  get_checksum > /tmp/checksum_file
-  cat /tmp/checksum_file
-  if md5sum -c /tmp/checksum_file > /dev/null ; then
-    echo "File has the right checksum, no download."
-  else
-    echo "WRONG checksum, need to download again."
-    download_war
-  fi
-
-else
-  echo "No WAR file found, downloading."
-  download_war
-fi
 
 # FIXME: Only hardcoded to install casc,
 # not following essentials.yaml declaration

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -150,7 +150,7 @@ test_jep_307() {
   result=$( docker exec $container_under_test curl -s https://jenkins.io/ )
   assertEquals "jenkins.io should be OK" "0" "$?"
 
-  # Incrementals, like http://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
+  # Incrementals, like https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
   result=$( docker exec $container_under_test curl -s https://repo.jenkins-ci.org )
   assertEquals "Incrementals repo should be OK" "0" "$?"
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -148,10 +148,14 @@ test_npm_5_plus() {
 # sites. See JEP-307
 test_jep_307() {
   result=$( docker exec $container_under_test curl -s https://jenkins.io/ )
-  assertEquals "0" "$?"
+  assertEquals "jenkins.io should be OK" "0" "$?"
+
+  # Incrementals, like http://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-war/maven-metadata.xml
+  result=$( docker exec $container_under_test curl -s https://repo.jenkins-ci.org )
+  assertEquals "Incrementals repo should be OK" "0" "$?"
 
   result=$( docker exec $container_under_test curl -s https://sonic.com/ )
-  assertEquals "60" "$?"
+  assertEquals "everything else should be KO" "60" "$?"
 }
 
 . ./shunit2/shunit2


### PR DESCRIPTION
This adjusts to https://github.com/jenkinsci/jenkins/pull/3394 and fixes the [JENKINS-51130](https://issues.jenkins-ci.org/browse/JENKINS-51130) which was now preventing any start of the Jenkins process in the evergreen image.