### PR TITLE
Ensure that a database dump occurs before running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ check: lint
 container-prereqs: build/jenkins-support build/jenkins.sh
 
 container-check: shunit2 ./tests/tests.sh containers
+	$(MAKE) -C services dump
 	./tests/offline-tests.sh
 	./tests/tests.sh
 


### PR DESCRIPTION
We need this to be able to seed the database properly for integration tests