### PR TITLE
 [JENKINS-51469] Move Metrics config under new "unclassified" root

### DIFF
--- a/config/jenkins-configuration.yaml
+++ b/config/jenkins-configuration.yaml
@@ -2,6 +2,8 @@
 jenkins:
   systemMessage: "Welcome to Jenkins Essentials!"
   numExecutors: 0
+
+unclassified:
   metricsaccesskey:
     accessKeys:
       - key: "evergreen"

--- a/services/src/services/update/update.hooks.js
+++ b/services/src/services/update/update.hooks.js
@@ -84,7 +84,7 @@ class UpdateHooks {
             }
           },
           {
-            'url' : 'http://mirrors.jenkins-ci.org/plugins/configuration-as-code/0.5-alpha/configuration-as-code.hpi',
+            'url' : 'https://repo.jenkins-ci.org/incrementals/io/jenkins/configuration-as-code/0.7-alpha-rc240.6e7dd119b0d3/configuration-as-code-0.7-alpha-rc240.6e7dd119b0d3.hpi',
             'checksum' : {
               'type' : 'sha256',
               'signature' : '703f04ad2820a39e131ec66de6872c13556f6a7345e3f50471c2ff7bf3d19f2c'


### PR DESCRIPTION
[JENKINS-51469](https://issues.jenkins-ci.org/browse/JENKINS-51469)

See also https://github.com/jenkinsci/configuration-as-code-plugin/pull/216