### PR TITLE
Add a `make fix-formatting` target

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -30,6 +30,11 @@ The `Makefile` at the project root should help you getting started.
 want to start to understand how things work, and be able to modify them and see
 the impact.
 
+=== Code style
+
+We have defined a set of ESLint rules to keep the code style consistent.
+To fix most, if not all, of the formatting issues, use `make fix-formatting`.
+
 === Tests
 
 Automated testing is exceptionally important for the Jenkins Essentials effort.

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ check: lint
 	$(MAKE) -C services $@
 	$(MAKE) container-check
 
+fix-formatting:
+	$(MAKE) -C client $@
+	$(MAKE) -C services $@
+
 container-prereqs: build/jenkins-support build/jenkins.sh
 
 container-check: shunit2 ./tests/tests.sh containers

--- a/client/Makefile
+++ b/client/Makefile
@@ -5,6 +5,9 @@ all: check
 lint:
 	$(NODE) npm run eslint
 
+fix-formatting:
+	$(NODE) npm run eslint -- --fix
+
 check: depends lint
 	$(MAKE) unit
 

--- a/services/Makefile
+++ b/services/Makefile
@@ -13,6 +13,9 @@ check: depends lint
 lint: depends
 	$(NODE) npm run eslint
 
+fix-formatting:
+	$(NODE) npm run eslint -- --fix
+
 unit:
 	$(COMPOSE) run -e NODE_ENV=test -e ERROR_LOGGING_FILE=/srv/evergreen/error-logging.json --rm node npm run jest
 


### PR DESCRIPTION
Following up on https://github.com/jenkins-infra/evergreen/pull/90, adding a `make fix-formatting` target to make it not cumbersome/easier to fix issues.

Tested locally on #90, by reverting all `.js` changes, and this fixed everything \o/.
