### PR TITLE
Check ingest.yaml with yamllint too, and fix it

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+rules:
+  line-length:
+    max: 100
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: false

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SCRIPTS_URL=https://raw.githubusercontent.com/jenkinsci/docker/master/
 all: check container
 
 lint: essentials.yaml shunit2
-	./tools/yamllint -s essentials.yaml
+	./tools/yamllint -s *.yaml
 	./tools/yamllint -s config/as-code/*.yaml
 	./tools/shellcheck -x tests/tests.sh
 

--- a/ingest.yaml
+++ b/ingest.yaml
@@ -8,16 +8,16 @@
 # example)
 timestamp: '2018-05-21T21:40:17+00:00'
 
-# Core defines the latest incremental jenkins.war artifact. 
+# Core defines the latest incremental jenkins.war artifact.
 core:
   # The URL referenced doesn't need to be sourced through a CDN, Artifactory is
   # suitable. Future versions of the Evergreen backend will need to point to a
   # CDN automatically anyways.
-  urL: 'http://mirrors.jenkins.io/war/latest/jenkins.war'
+  url: 'http://mirrors.jenkins.io/war/latest/jenkins.war'
   # The checksum is important for the Evergreen backend services, and client,
   # to verify the artifact but also to distinguish effectively between two
   # files which might be referenced in multiple ingest manifests which are in
-  # fact the same. 
+  # fact the same.
   checksum:
     # The type of supported checksum will need to be negotiated with the
     # client-side support. Currently only sha256 is supported.

--- a/tools/yamllint
+++ b/tools/yamllint
@@ -3,4 +3,4 @@
 exec docker run --rm \
     -w ${PWD} \
     -v ${PWD}:${PWD} \
-    boiyaa/yamllint $@
+    boiyaa/yamllint:1.8.1 $@


### PR DESCRIPTION
Well, "fix" it. As the line-length made no sense to me to scavenge the config file for, I preferred to bump the 1950's default of 80 to 100.