### PR TITLE
[JENKINS-51731] Running a standalone Pipeline should be feasible out of the box

### DIFF
--- a/services/src/services/update/update.hooks.js
+++ b/services/src/services/update/update.hooks.js
@@ -133,6 +133,13 @@ class UpdateHooks {
             }
           },
           {
+            'url' : 'https://updates.jenkins.io/latest/durable-task.hpi',
+            'checksum' : {
+              'type' : 'sha256',
+              'signature' : 'c4f964c6deb599816f6740ef674cb6dd2644d5f1b4e7b886a948f778ec5c189e'
+            }
+          },
+          {
             'url' : 'https://updates.jenkins.io/latest/essentials.hpi',
             'checksum' : {
               'type' : 'sha256',
@@ -225,6 +232,13 @@ class UpdateHooks {
           },
           {
             'url' : 'https://updates.jenkins.io/latest/workflow-cps.hpi',
+            'checksum' : {
+              'type' : 'sha256',
+              'signature' : '1861d2cd288f7cb81c404647b9bf4a863aea3625fad73d0c8a0930b7742c5eea'
+            }
+          },
+          {
+            'url' : 'https://updates.jenkins.io/latest/workflow-durable-task-step.hpi',
             'checksum' : {
               'type' : 'sha256',
               'signature' : '1861d2cd288f7cb81c404647b9bf4a863aea3625fad73d0c8a0930b7742c5eea'


### PR DESCRIPTION
[JENKINS-51731](https://issues.jenkins-ci.org/browse/JENKINS-51731) 

_Discovered_ as I was trying to use a simple standalone pipeline during a demo today, when not installing any additional plugin with the wizard.
In my previous testing I had used freestyle jobs :man_facepalming:...

Even if we will anyway totally rewrire this part, this seems like an acceptably small and easy short term fix.

----

Manually tested using `make run` for now.
Once I complete [JENKINS-49866](https://issues.jenkins-ci.org/browse/JENKINS-49866), I will add an automated test to check this keeps working.