### PR TITLE
[JENKINS-51391] Adjust error telemetry API to JEP-308

### DIFF
--- a/services/acceptance/helpers.js
+++ b/services/acceptance/helpers.js
@@ -39,7 +39,7 @@ class Helpers {
 
   assertStatus(response, code) {
     if (response.statusCode) {
-      assert.equal(response.statusCode, code);
+      assert.equal(response.statusCode, code, 'expected: ' + code + ', received: ' + response.statusCode);
     }
     else {
       throw response;

--- a/services/acceptance/services/errortelemetry.test.js
+++ b/services/acceptance/services/errortelemetry.test.js
@@ -56,6 +56,35 @@ describe('Error Telemetry service acceptance tests', () => {
           });
       });
 
+      it('should reject invalid json', () => {
+        return request({
+          url: h.getUrl('/telemetry/error'),
+          method: 'POST',
+          headers: { 'Authorization': this.token },
+          json: true,
+          body: 'invalid json'
+        })
+          .then(res => assert.fail(res))
+          .catch(err => {
+            h.assertStatus(err, 400);
+          });
+      });
+
+      it('should reject large payloads', () => {
+        let largeLog = new Array(1000001).join('a');
+        return request({
+          url: h.getUrl('/telemetry/error'),
+          method: 'POST',
+          headers: { 'Authorization': this.token },
+          json: true,
+          body: largeLog
+        })
+          .then(res => assert.fail(res))
+          .catch(err => {
+            h.assertStatus(err, 413);
+          });
+      });
+
       it('should accept correctly formatted logs', () => {
         let emptyLog = {
           uuid: this.reg.uuid,

--- a/services/acceptance/services/errortelemetry.test.js
+++ b/services/acceptance/services/errortelemetry.test.js
@@ -71,7 +71,20 @@ describe('Error Telemetry service acceptance tests', () => {
       });
 
       it('should reject large payloads', () => {
-        let largeLog = new Array(1000001).join('a');
+        let largeMessage = new Array(1000001).join('a');
+        let largeLog = {
+          uuid: this.reg.uuid,
+          log: {
+            version: 1,
+            timestamp: 1522840762769,
+            name: 'io.jenkins.plugins.SomeTypicalClass',
+            level: 'WARNING',
+            message: largeMessage,
+            exception: {
+              raw: 'serialized exception\n many \n many \n lines'
+            }
+          }
+        };
         return request({
           url: h.getUrl('/telemetry/error'),
           method: 'POST',

--- a/services/src/app.js
+++ b/services/src/app.js
@@ -74,9 +74,12 @@ app.configure(channels);
 // Configure a middleware for 404s and the error handler
 app.use(express.notFound());
 
-/* eslint-disable no-unused-vars */
 app.use((err, req, res, next) => { 
-  if (!err.statusCode) err.statusCode = err.code ? err.code : 500;
+  if (res.headersSent) {
+    return next(err);
+  }
+  if (!err.statusCode) 
+    err.statusCode = (err.code ? err.code : 500);
   if (!err.message) err.message = 'Unexpected server error';
   /* Avoid cluttering the test logs with expected errors and exceptions */
   if (process.env.NODE_ENV != 'test') {
@@ -86,7 +89,6 @@ app.use((err, req, res, next) => {
   res.status(err.statusCode);
   res.json({ status: FAILURE, message: err.message });
 });
-/* eslint-enable no-unused-vars */
 
 app.hooks(appHooks);
 


### PR DESCRIPTION
[JENKINS-51391](https://issues.jenkins-ci.org/browse/JENKINS-51391)

I added a custom error handler to standardize the format of the error responses.