### PR TITLE
Enable more ESlint rules for codebase consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ lint:
 check:
 	$(MAKE) -C distribution $@
 	$(MAKE) -C services $@
+
+fix-formatting:
+	$(MAKE) -C distribution $@
+	$(MAKE) -C services $@

--- a/distribution/client/.eslintrc.json
+++ b/distribution/client/.eslintrc.json
@@ -36,6 +36,9 @@
     "spaced-comment": "error",
     "space-infix-ops": "error",
     "semi-spacing": "error",
-    "template-tag-spacing": "error"
+    "template-tag-spacing": "error",
+    "curly": "error",
+    "brace-style": "error",
+    "no-trailing-spaces": "error"
   }
 }

--- a/distribution/client/src/client.js
+++ b/distribution/client/src/client.js
@@ -114,8 +114,7 @@ class Client {
         return this.status.create().then(() => {
           this.runloop(this.app);
         });
-      }
-      else {
+      } else {
         return this.runloop(this.app);
       }
     }).catch((err) => {

--- a/distribution/client/src/lib/periodic.js
+++ b/distribution/client/src/lib/periodic.js
@@ -49,5 +49,7 @@ class Periodic {
   }
 }
 
-module.exports = function(app, options) { return new Periodic(app, options); };
+module.exports = function(app, options) {
+  return new Periodic(app, options);
+};
 module.exports.Periodic = Periodic;

--- a/distribution/client/src/lib/registration.js
+++ b/distribution/client/src/lib/registration.js
@@ -31,8 +31,7 @@ class Registration {
     try {
       fs.statSync(this.uuidPath());
       return true;
-    }
-    catch (err) {
+    } catch (err) {
       if (err.code == 'ENOENT') {
         return false;
       }
@@ -56,8 +55,7 @@ class Registration {
         self.loadKeysSync();
         self.loadUUIDSync();
         return self.login().then(res => resolve(res, false));
-      }
-      else {
+      } else {
         if (!self.generateKeys()) {
           return reject('Failed to generate keys');
         }
@@ -73,8 +71,7 @@ class Registration {
           self.uuid = res.uuid;
           if (!self.saveUUIDSync()) {
             reject('Failed to save UUID!');
-          }
-          else {
+          } else {
             return self.login().then(res => resolve(res, true));
           }
         }).catch((res) => {
@@ -169,12 +166,10 @@ class Registration {
     try {
       fs.statSync(this.uuidPath());
       return true;
-    }
-    catch (err) {
+    } catch (err) {
       if (err.code == 'ENOENT') {
         return false;
-      }
-      else {
+      } else {
         throw err;
       }
     }
@@ -231,12 +226,10 @@ class Registration {
     try {
       fs.statSync(this.publicKeyPath());
       return true;
-    }
-    catch (err) {
+    } catch (err) {
       if (err.code == 'ENOENT') {
         return false;
-      }
-      else {
+      } else {
         throw err;
       }
     }
@@ -252,12 +245,10 @@ class Registration {
     /* Only bother making the directory if it doesn't already exist */
     try {
       fs.statSync(keys);
-    }
-    catch (err) {
+    } catch (err) {
       if (err.code == 'ENOENT') {
         mkdirp.sync(keys);
-      }
-      else {
+      } else {
         throw err;
       }
     }

--- a/distribution/client/src/lib/status.js
+++ b/distribution/client/src/lib/status.js
@@ -50,8 +50,7 @@ class Status {
          */
         if (err.code != 400) {
           logger.error('Failed to create a Status record', err);
-        }
-        else {
+        } else {
           logger.debug('Status record not changed');
         }
       });
@@ -67,7 +66,9 @@ class Status {
 
       zip.on('ready', () => {
         zip.stream(manifestName, (err, stream) => {
-          if (err) { reject(err); }
+          if (err) {
+            reject(err);
+          }
           let buffer = '';
           stream.on('data', chunk => buffer += chunk );
           stream.on('end', () => {

--- a/distribution/client/src/lib/update.js
+++ b/distribution/client/src/lib/update.js
@@ -60,12 +60,10 @@ class Update {
   loadUpdateSync() {
     try {
       fs.statSync(this.updatePath());
-    }
-    catch (err) {
+    } catch (err) {
       if (err.code == 'ENOENT') {
         return null;
-      }
-      else {
+      } else {
         throw err;
       }
     }
@@ -85,12 +83,10 @@ class Update {
 
     try {
       fs.statSync(dir);
-    }
-    catch (err) {
+    } catch (err) {
       if (err.code == 'ENOENT') {
         mkdirp.sync(storage.homeDirectory());
-      }
-      else {
+      } else {
         throw err;
       }
     }

--- a/distribution/client/test/registration.test.js
+++ b/distribution/client/test/registration.test.js
@@ -48,12 +48,10 @@ describe('The registration module', () => {
         assert(this.reg.saveUUIDSync());
         try {
           fs.statSync(this.reg.uuidPath());
-        }
-        catch (err) {
+        } catch (err) {
           if (err.code == 'ENOENT') {
             assert.fail('Could not find the uuid saved on disk');
-          }
-          else {
+          } else {
             throw err;
           }
         }
@@ -91,8 +89,7 @@ describe('The registration module', () => {
         assert(this.reg.saveKeysSync());
         try {
           fs.statSync(this.reg.publicKeyPath());
-        }
-        catch (err) {
+        } catch (err) {
           assert.fail('The public key was not written properly');
         }
 
@@ -101,8 +98,7 @@ describe('The registration module', () => {
             'evergreen-private-key'].join(path.sep);
 
           fs.statSync(privateKeyPath);
-        }
-        catch (err) {
+        } catch (err) {
           assert.fail('The private key was not written properly');
         }
       });
@@ -172,8 +168,7 @@ describe('The registration module', () => {
       /* this is really a test to make sure memfs is behaving appropriately */
       try {
         fs.statSync('/evergreen/keys');
-      }
-      catch (err) {
+      } catch (err) {
         assert.equal(err.code, 'ENOENT');
       }
     });

--- a/distribution/client/test/update.test.js
+++ b/distribution/client/test/update.test.js
@@ -36,12 +36,10 @@ describe('The update module', () => {
       assert(update.saveUpdateSync());
       try {
         fs.statSync(update.updatePath());
-      }
-      catch (err) {
+      } catch (err) {
         if (err.code == 'ENOENT') {
           assert.fail('Could not find the updates saved on disk');
-        }
-        else {
+        } else {
           throw err;
         }
       }

--- a/services/.eslintrc.json
+++ b/services/.eslintrc.json
@@ -36,6 +36,9 @@
     "spaced-comment": "error",
     "space-infix-ops": "error",
     "semi-spacing": "error",
-    "template-tag-spacing": "error"
+    "template-tag-spacing": "error",
+    "curly": "error",
+    "brace-style": "error",
+    "no-trailing-spaces": "error"
   }
 }

--- a/services/acceptance/helpers.js
+++ b/services/acceptance/helpers.js
@@ -40,8 +40,7 @@ class Helpers {
   assertStatus(response, code) {
     if (response.statusCode) {
       assert.equal(response.statusCode, code, 'expected: ' + code + ', received: ' + response.statusCode);
-    }
-    else {
+    } else {
       throw response;
     }
   }

--- a/services/acceptance/services/version.test.js
+++ b/services/acceptance/services/version.test.js
@@ -94,8 +94,7 @@ describe('Versions service acceptance tests', () => {
         try {
           await request(req);
           assert.fail('Should not have succeeded');
-        }
-        catch (err) {
+        } catch (err) {
           h.assertStatus(err, 400);
         }
       });

--- a/services/src/app.js
+++ b/services/src/app.js
@@ -74,13 +74,16 @@ app.configure(channels);
 // Configure a middleware for 404s and the error handler
 app.use(express.notFound());
 
-app.use((err, req, res, next) => { 
+app.use((err, req, res, next) => {
   if (res.headersSent) {
     return next(err);
   }
-  if (!err.statusCode) 
+  if (!err.statusCode) {
     err.statusCode = (err.code ? err.code : 500);
-  if (!err.message) err.message = 'Unexpected server error';
+  }
+  if (!err.message) {
+    err.message = 'Unexpected server error';
+  }
   /* Avoid cluttering the test logs with expected errors and exceptions */
   if (process.env.NODE_ENV != 'test') {
     logger.error(err.stack);

--- a/services/src/hooks/ensureuuid.js
+++ b/services/src/hooks/ensureuuid.js
@@ -27,8 +27,7 @@ module.exports = function(context) {
     // if (context.data.uuid != context.params.query.uuid) {
     //   throw new errors.NotAuthenticated('Invalid UUID');
     // }
-  }
-  else {
+  } else {
     if (!context.data.uuid) {
       throw new errors.BadRequest('Invalid UUID in data body');
     }

--- a/services/src/sequelize-swagger.js
+++ b/services/src/sequelize-swagger.js
@@ -12,7 +12,9 @@ const _ = require('lodash');
 module.exports = function() {
   const app = this;
   // Check for swagger
-  if (_.isNil(app.docs)) throw new Error('no swagger defined');
+  if (_.isNil(app.docs)) {
+    throw new Error('no swagger defined');
+  }
   // Iterate over the doc paths, find the service
   _(app.docs.paths)
     .keys()

--- a/services/src/services/authentication/authentication.class.js
+++ b/services/src/services/authentication/authentication.class.js
@@ -21,4 +21,6 @@ class Authentication {
   }
 }
 
-module.exports = function(options) { return new Authentication(options); };
+module.exports = function(options) {
+  return new Authentication(options);
+};

--- a/services/src/services/authentication/authentication.hooks.js
+++ b/services/src/services/authentication/authentication.hooks.js
@@ -26,8 +26,7 @@ class AuthenticationHooks {
     return reg.find({ query: { uuid: context.data.uuid }}).then(records => {
       if (records.total < 1) {
         throw new errors.NotFound('Unknown instance');
-      }
-      else {
+      } else {
         /*
         * Since we've already looked up the UUID, let's pass it along for
         * future hook use
@@ -58,8 +57,7 @@ class AuthenticationHooks {
       if (!key.verify(record.uuid, context.data.signature)) {
         throw invalidError;
       }
-    }
-    catch (err) {
+    } catch (err) {
       logger.error('Improperly formed signature sent', err.message);
       throw invalidError;
     }

--- a/services/src/services/errorTelemetry/errorTelemetry.class.js
+++ b/services/src/services/errorTelemetry/errorTelemetry.class.js
@@ -35,5 +35,7 @@ class ErrorTelemetryService {
   }
 }
 
-module.exports = function() { return new ErrorTelemetryService(); };
+module.exports = function() {
+  return new ErrorTelemetryService();
+};
 module.exports.ErrorTelemetryService = ErrorTelemetryService;

--- a/services/src/services/update/update.hooks.js
+++ b/services/src/services/update/update.hooks.js
@@ -49,8 +49,7 @@ class UpdateHooks {
           createdAt: 1,
         }
       });
-    }
-    else {
+    } else {
       Object.assign(query, {
         $sort: {
           createdAt: -1,

--- a/services/test/services/status.hooks.test.js
+++ b/services/test/services/status.hooks.test.js
@@ -57,7 +57,9 @@ describe('status service hooks', () => {
          */
         context.app.service = () => {
           return {
-            find: () => { return {}; },
+            find: () => {
+              return {};
+            },
           };
         };
 


### PR DESCRIPTION
Enabling a bit more rules so that the codestyle overall stays more consistent.

Also added the `fix-formatting` rule at the root `Makefile` to make fixing this when it happens even easier.
I didn't have to make a single fix manually, all were done using `make fix-formatting`.