### PR TITLE
Enable forced/cron build every 6 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,7 @@ pipeline {
 
     triggers {
         pollSCM('H * * * *')
+        cron('H */6 * * *')
     }
 
     stages {


### PR DESCRIPTION
To catch issues with possible "upstream" components like plugins or
others that might make master fail.
Goal is to generally catch issues, and more specifically avoid
developers scratching their heads for hours before realizing their
additions have nothing to do with the given failure.

NOTE: expected to fail because of the 4.x release of the `metrics` plugin and the fact we still depend on `master` on the latest version of most plugins.