### PR TITLE
[JENKINS-52122] check essentials and metrics plugins are installed

### DIFF
--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -41,6 +41,14 @@ test_smoke() {
 
 }
 
+test_required_plugins_are_here() {
+  docker exec "$container_under_test" ls "$JENKINS_HOME/plugins/metrics.hpi" > /dev/null
+  assertEquals "The metrics plugin should be installed" 0 "$?"
+
+  docker exec "$container_under_test" ls "$JENKINS_HOME/plugins/essentials.hpi" > /dev/null
+  assertEquals "The essentials plugin should be installed" 0 "$?"
+}
+
 # FIXME JENKINS-51328 to re-enable
 test_no_node_error_in_logs() {
 

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -42,11 +42,15 @@ test_smoke() {
 }
 
 test_required_plugins_are_here() {
-  docker exec "$container_under_test" ls "$JENKINS_HOME/plugins/metrics.hpi" > /dev/null
+  docker exec "$container_under_test" ls "$JENKINS_HOME/plugins/metrics.hpi"
   assertEquals "The metrics plugin should be installed" 0 "$?"
 
-  docker exec "$container_under_test" ls "$JENKINS_HOME/plugins/essentials.hpi" > /dev/null
+  # workaround for JENKINS-52197
+  docker exec "$container_under_test" bash -c 'ls $JENKINS_HOME/plugins/essentials*.hpi'
   assertEquals "The essentials plugin should be installed" 0 "$?"
+
+  docker exec "$container_under_test" bash -c 'ls $JENKINS_HOME/plugins/configuration-as-code*.hpi'
+  assertEquals "The configuration-as-code plugin should be installed" 0 "$?"
 }
 
 # FIXME JENKINS-51328 to re-enable

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -46,9 +46,11 @@ test_required_plugins_are_here() {
   assertEquals "The metrics plugin should be installed" 0 "$?"
 
   # workaround for JENKINS-52197
+  # shellcheck disable=SC2016
   docker exec "$container_under_test" bash -c 'ls $JENKINS_HOME/plugins/essentials*.hpi'
   assertEquals "The essentials plugin should be installed" 0 "$?"
 
+  # shellcheck disable=SC2016
   docker exec "$container_under_test" bash -c 'ls $JENKINS_HOME/plugins/configuration-as-code*.hpi'
   assertEquals "The configuration-as-code plugin should be installed" 0 "$?"
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-52122

Goal is to avoid losing time each time one changes the plugin list, and might end up removing those Essentials-required plugins unintendedly.