### PR TITLE
[JENKINS-52163] update acceptance tests to use expect

### DIFF
--- a/services/acceptance/app.test.js
+++ b/services/acceptance/app.test.js
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const rp = require('request-promise');
 const url = require('url');
 const app = require('../src/app');
@@ -22,8 +21,8 @@ describe('Feathers application tests', () => {
   });
 
   it('starts and shows the index page', () => {
-    return rp(getUrl()).then(body =>
-      assert.ok(body.indexOf('<html>') !== -1)
-    );
+    return rp(getUrl()).then(body => {
+      expect(body).toEqual(expect.stringContaining('<html>'));
+    });
   });
 });

--- a/services/acceptance/helpers.js
+++ b/services/acceptance/helpers.js
@@ -2,7 +2,6 @@
  * This module contains functions which are helpful for running all acceptance
  * tests
  */
-const assert  = require('assert');
 const ecc     = require('elliptic');
 const request = require('request-promise');
 const url     = require('url');
@@ -35,14 +34,6 @@ class Helpers {
       port: this.port(),
       pathname
     });
-  }
-
-  assertStatus(response, code) {
-    if (response.statusCode) {
-      assert.equal(response.statusCode, code, 'expected: ' + code + ', received: ' + response.statusCode);
-    } else {
-      throw response;
-    }
   }
 
   /*

--- a/services/acceptance/services/authentication.test.js
+++ b/services/acceptance/services/authentication.test.js
@@ -14,7 +14,7 @@ describe('Authentication service acceptance tests', () => {
         method: 'POST'
       })
         .then(() => assert.fail('Got a 200 response'))
-        .catch(res => h.assertStatus(res, 400));
+        .catch(err => expect(err.statusCode).toEqual(400));
     });
 
     it('should handle redundant slashes correctly', () => {
@@ -23,7 +23,7 @@ describe('Authentication service acceptance tests', () => {
         method: 'POST'
       })
         .then(() => assert.fail('Got a 200 response'))
-        .catch(res => h.assertStatus(res, 400));
+        .catch(err => expect(err.statusCode).toEqual(400));
     });
 
     it('should return a 404 if the client has not registered', () => {
@@ -37,7 +37,7 @@ describe('Authentication service acceptance tests', () => {
         }
       })
         .then(() => assert.fail('Got a 200 response'))
-        .catch(res => h.assertStatus(res, 404));
+        .catch(err => expect(err.statusCode).toEqual(404));
     });
 
     describe('with a pre-existing registration', () => {
@@ -57,7 +57,7 @@ describe('Authentication service acceptance tests', () => {
           }
         })
           .then(() => assert.fail('Should not have succeeded'))
-          .catch((err) => assert.equal(err.statusCode, 400));
+          .catch(err => expect(err.statusCode).toEqual(400));
       });
 
       it('should create a JWT token if the client has registered', async () => {
@@ -74,7 +74,7 @@ describe('Authentication service acceptance tests', () => {
           }
         });
         /* ensure this response looks somewhat tokeny? */
-        assert.ok(auth);
+        expect(auth).toBeTruthy();
       });
     });
   });

--- a/services/acceptance/services/errortelemetry.test.js
+++ b/services/acceptance/services/errortelemetry.test.js
@@ -14,7 +14,7 @@ describe('Error Telemetry service acceptance tests', () => {
         method: 'POST'
       })
         .then(() => assert.fail('This should not have succeeded'))
-        .catch((err) => h.assertStatus(err, 401));
+        .catch((err) => expect(err.statusCode).toEqual(401));
     });
   });
 
@@ -52,9 +52,9 @@ describe('Error Telemetry service acceptance tests', () => {
         })
           .then(res => assert.fail(res))
           .catch(err => {
-            assert.equal(err.statusCode, 400);
-            assert.equal(err.error.status, 'ERROR', 'response.status should be ERROR but got: ' + err.error.status);
-            assert.equal(err.error.message, 'Missing required field \'version\'', 'response.message got: ' + err.error.message);
+            expect(err.statusCode).toEqual(400);
+            expect(err.error.status).toEqual('ERROR');
+            expect(err.error.message).toEqual('Missing required field \'version\'');
           });
       });
 
@@ -68,9 +68,9 @@ describe('Error Telemetry service acceptance tests', () => {
         })
           .then(res => assert.fail(res))
           .catch(err => {
-            h.assertStatus(err, 400);
-            assert.equal(err.error.status, 'ERROR', 'response.status should be ERROR but got: ' + err.error.status);
-            assert.equal(err.error.message, 'Unexpected token " in JSON at position 0', 'response.message got: ' + err.error.message);
+            expect(err.statusCode).toEqual(400);
+            expect(err.error.status).toEqual('ERROR');
+            expect(err.error.message).toEqual('Unexpected token " in JSON at position 0');
           });
       });
 
@@ -98,8 +98,8 @@ describe('Error Telemetry service acceptance tests', () => {
         })
           .then(res => assert.fail(res))
           .catch(err => {
-            h.assertStatus(err, 413);
-            assert.equal(err.error.status, 'ERROR', 'response.status should be ERROR but got: ' + err.error.status);
+            expect(err.statusCode).toEqual(413);
+            expect(err.error.status).toEqual('ERROR');
           });
       });
 
@@ -125,8 +125,8 @@ describe('Error Telemetry service acceptance tests', () => {
           body: emptyLog
         })
           .then(res => {
-            assert.ok(res);
-            assert.equal(res.status, 'OK', 'response.status should be OK but got: ' + res.status);
+            expect(res).toBeTruthy();
+            expect(res.status).toEqual('OK');
           })
           .catch(err => assert.fail(err));
       });

--- a/services/acceptance/services/registration.test.js
+++ b/services/acceptance/services/registration.test.js
@@ -12,13 +12,17 @@ describe('Registration service acceptance tests', () => {
         url: h.getUrl('/registration'),
         method: 'POST',
         json: true,
+        resolveWithFullResponse: true,
         body: {
           pubKey: 'pretend-pubkey',
           curve: 'secp256k1'
         }
       })
-        .then(res => assert.ok(res.uuid, 'Missing a uuid'))
-        .catch(res => assert.equal(res.statusCode, 201));
+        .then(res => {
+          expect(res.statusCode).toEqual(201);
+          expect(res.body.uuid).toBeTruthy();
+        })
+        .catch((err) => assert.fail(err));
     });
 
     it('should fail when there is no curve', async () => {
@@ -31,7 +35,7 @@ describe('Registration service acceptance tests', () => {
         }
       })
         .then(() => assert.fail('Should have failed'))
-        .catch(res => assert.equal(res.statusCode, 400));
+        .catch(err => expect(err.statusCode).toEqual(400));
     });
   });
 
@@ -40,7 +44,7 @@ describe('Registration service acceptance tests', () => {
       url: h.getUrl('/registration/some-uuid'),
     })
       .then(() => assert.fail('Got a 200 response'))
-      .catch(res => h.assertStatus(res, 405));
+      .catch(err => expect(err.statusCode).toEqual(405));
   });
 
   it('should not support updates', () => {
@@ -49,7 +53,7 @@ describe('Registration service acceptance tests', () => {
       method: 'PUT',
     })
       .then(() => assert.fail('Got a 200 response'))
-      .catch(res => h.assertStatus(res, 405));
+      .catch(err => expect(err.statusCode).toEqual(405));
   });
 
   it('should not support patches', () => {
@@ -58,7 +62,7 @@ describe('Registration service acceptance tests', () => {
       method: 'PATCH',
     })
       .then(() => assert.fail('Got a 200 response'))
-      .catch(res => h.assertStatus(res, 405));
+      .catch(err => expect(err.statusCode).toEqual(405));
   });
 
   it('should not support deletes', () => {
@@ -67,7 +71,7 @@ describe('Registration service acceptance tests', () => {
       method: 'DELETE',
     })
       .then(() => assert.fail('Got a 200 response'))
-      .catch(res => h.assertStatus(res, 405));
+      .catch(err => expect(err.statusCode).toEqual(405));
   });
 
   it('should not support finds', () => {
@@ -75,6 +79,6 @@ describe('Registration service acceptance tests', () => {
       url: h.getUrl('/registration'),
     })
       .then(() => assert.fail('Got a 200 response'))
-      .catch(res => h.assertStatus(res, 405));
+      .catch(err => expect(err.statusCode).toEqual(405));
   });
 });

--- a/services/acceptance/services/status.test.js
+++ b/services/acceptance/services/status.test.js
@@ -11,8 +11,8 @@ describe('Status service acceptance tests', () => {
       url: h.getUrl('/status'),
       json: true
     })
-      .then(() => assert.fail('This should not have succeeded'))
-      .catch((err) => h.assertStatus(err, 401));
+      .then((res) => assert.fail(res))
+      .catch((err) => expect(err.statusCode).toEqual(401));
   });
 
   describe('with a pre-existing registration', () => {
@@ -27,10 +27,14 @@ describe('Status service acceptance tests', () => {
         return request({
           url: h.getUrl('/status'),
           headers: { 'Authorization': this.token },
-          json: true
+          json: true,
+          resolveWithFullResponse: true
         })
-          .then(r => assert.ok(r))
-          .catch((err) => h.assertStatus(err, 200));
+          .then(res => {
+            expect(res.statusCode).toEqual(200);
+            expect(res).toBeTruthy();
+          })
+          .catch((err) => assert.fail(err));
       });
 
       describe('POST /status (create)', () => {
@@ -43,8 +47,8 @@ describe('Status service acceptance tests', () => {
             body: { uuid: this.uuid }
           });
 
-          assert.ok(response);
-          assert.ok(response.updateId);
+          expect(response).toBeTruthy();
+          expect(response.updateId).toBeTruthy();
         });
 
         it('should not allow creating a status for a uuid not in the JWT', () => {
@@ -55,8 +59,8 @@ describe('Status service acceptance tests', () => {
             json: true,
             body: { uuid: 'fake out!' }
           })
-            .then(() => assert.fail('Should have failed'))
-            .catch(err => h.assertStatus(err, 401));
+            .then(res => assert.fail(res))
+            .catch(err => expect(err.statusCode).toEqual(401));
         });
       });
 
@@ -82,15 +86,15 @@ describe('Status service acceptance tests', () => {
           });
 
           it('should return the right uuid in the record', () => {
-            assert.ok(this.response);
-            assert.equal(this.response.uuid, this.instanceId);
+            expect(this.response).toBeTruthy();
+            expect(this.response.uuid).toEqual(this.instanceId);
           });
 
           it('should return the proper `channel` relationship', () => {
-            assert.ok(this.response);
-            assert.ok(this.response.update);
+            expect(this.response).toBeTruthy();
+            expect(this.response.update).toBeTruthy();
             /* we expect everybody to be in the general channel by default */
-            assert.equal(this.response.update.channel, 'general');
+            expect(this.response.update.channel).toEqual('general');
           });
         });
 
@@ -103,8 +107,8 @@ describe('Status service acceptance tests', () => {
               json: true,
               body: { uuid: this.instanceId }
             })
-              .then(() => assert.fail('This should fail'))
-              .catch(err => h.assertStatus(err, 400));
+              .then(res => assert.fail(res))
+              .catch(err => expect(err.statusCode).toEqual(400));
           });
         });
       });

--- a/services/acceptance/services/update.test.js
+++ b/services/acceptance/services/update.test.js
@@ -5,6 +5,7 @@
 
 const fs   = require('fs');
 
+const assert  = require('assert');
 const request = require('request-promise');
 const h       = require('../helpers');
 
@@ -29,11 +30,14 @@ describe('Update service acceptance tests', () => {
         url: h.getUrl('/update'),
         method: 'POST',
         json: true,
+        resolveWithFullResponse: true,
         headers: { 'Authorization': this.settings.internalAPI.secret },
         body: {}
       })
-        .then(r => expect(r))
-        .catch((err) => h.assertStatus(err, 400));
+        .then(res => assert.fail(res.body))
+        .catch(err => {
+          expect(err.statusCode).toEqual(400);
+        });
     });
 
     it('should treat a valid "ingest JSON" as valid', () => {
@@ -42,13 +46,17 @@ describe('Update service acceptance tests', () => {
         method: 'POST',
         headers: { 'Authorization': this.settings.internalAPI.secret },
         json: true,
+        resolveWithFullResponse: true,
         body: {
           commit: '0xdeadbeef',
           manifest: this.ingest,
         },
       })
-        .then(r => expect(r.id).toBeGreaterThan(0))
-        .catch((err) => h.assertStatus(err, 200));
+        .then(res => {
+          expect(res.statusCode).toEqual(201);
+          expect(res.body.id).toBeGreaterThan(0);
+        })
+        .catch((err) => assert.fail(err));
     });
   });
 });

--- a/services/acceptance/services/version.test.js
+++ b/services/acceptance/services/version.test.js
@@ -1,4 +1,3 @@
-const assert  = require('assert');
 const request = require('request-promise');
 const h       = require('../helpers');
 
@@ -63,10 +62,13 @@ describe('Versions service acceptance tests', () => {
           method: 'POST',
           headers: { 'Authorization': this.token },
           json: true,
+          resolveWithFullResponse: true,
           body: version
         })
-          .then(res => assert.ok(res))
-          .catch(err => assert.fail(err));
+          .then(res => {
+            expect(res.body.uuid).toBeTruthy();
+          })
+          .catch(() => expect(false).toBeTruthy());
       });
 
       it('should not allow creating a versions record for some other uuid', () => {
@@ -77,8 +79,8 @@ describe('Versions service acceptance tests', () => {
           json: true,
           body: { uuid: 'phony', manifest: manifest }
         })
-          .then(() => assert.fail('Should have failed'))
-          .catch(err => h.assertStatus(err, 401));
+          .then(() => expect(false).toBeTruthy())
+          .catch(err => expect(err.statusCode).toEqual(401));
       });
 
       it('should disallow creating redundant versions records', async () => {
@@ -93,9 +95,9 @@ describe('Versions service acceptance tests', () => {
 
         try {
           await request(req);
-          assert.fail('Should not have succeeded');
+          expect(false).toBeTruthy();
         } catch (err) {
-          h.assertStatus(err, 400);
+          expect(err.statusCode).toEqual(400);
         }
       });
     });

--- a/services/src/services/update/update.hooks.js
+++ b/services/src/services/update/update.hooks.js
@@ -20,10 +20,7 @@ class UpdateHooks {
   }
 
   checkUpdateFormat(hook) {
-    if (!hook) {
-      throw new errors.BadRequest('No hook at all?');
-    }
-    if (!(hook.data)) {
+    if (!(hook.data) || !Object.keys(hook.data).length) {
       throw new errors.BadRequest('Missing data');
     }
     if (!(hook.data.commit)) {

--- a/services/src/services/update/update.hooks.js
+++ b/services/src/services/update/update.hooks.js
@@ -4,6 +4,7 @@ const ensureMatchingUUID = require('../../hooks/ensureuuid');
 const internalOnly       = require('../../hooks/internalonly');
 const authentication     = require('@feathersjs/authentication');
 const internalApi        = require('../../hooks/internalapi');
+const errors             = require('@feathersjs/errors');
 
 class UpdateHooks {
   constructor() {
@@ -16,6 +17,19 @@ class UpdateHooks {
   defaultChannel(context) {
     context.data.channel = 'general';
     return context;
+  }
+
+  checkUpdateFormat(hook) {
+    if (!hook) {
+      throw new errors.BadRequest('No hook at all?');
+    }
+    if (!(hook.data)) {
+      throw new errors.BadRequest('Missing data');
+    }
+    if (!(hook.data.commit)) {
+      throw new errors.BadRequest('Missing commit field');
+    }
+    // TODO add required field validation once we know what the required fields are
   }
 
   getHooks() {
@@ -32,6 +46,7 @@ class UpdateHooks {
         ],
         create: [
           internalApi,
+          this.checkUpdateFormat,
           dbtimestamp('createdAt'),
           this.defaultChannel,
         ],


### PR DESCRIPTION
[JENKINS-52163](https://issues.jenkins-ci.org/browse/JENKINS-52163)

Update acceptance tests to use expect where possible.  There's no simple expect equivalent to assert.fail.

Added a hook to the update create path to fix a test so that it fails as expected.