### PR TITLE
Name test runs folders with flavor and test file name to ease diagnostics

### DIFF
--- a/distribution/tests/utilities
+++ b/distribution/tests/utilities
@@ -22,7 +22,7 @@ cleanup () {
   fi
   currentCommand="$( basename $0 )"
   theDate=$( date +%Y-%m-%d_%H-%M-%S )
-  testRunDirectory=build/tests-run-$theDate-$currentCommand-$flavor
+  testRunDirectory=build/tests-run-$theDate-$flavor-$currentCommand
   mkdir -p $testRunDirectory
 
   echo -n "Retrieving test run data (container logs, ...) before shutdown... Will be in the $testRunDirectory directory... "

--- a/distribution/tests/utilities
+++ b/distribution/tests/utilities
@@ -16,8 +16,13 @@ info() {
 cleanup () {
   echo
 
+  flavor=no-flavor
+  if [[ -n $ENVIRONMENT ]]; then
+    flavor=$ENVIRONMENT
+  fi
+  currentCommand="$( basename $0 )"
   theDate=$( date +%Y-%m-%d_%H-%M-%S )
-  testRunDirectory=build/tests-run-$theDate
+  testRunDirectory=build/tests-run-$theDate-$currentCommand-$flavor
   mkdir -p $testRunDirectory
 
   echo -n "Retrieving test run data (container logs, ...) before shutdown... Will be in the $testRunDirectory directory... "


### PR DESCRIPTION
In CI and locally, it can be very time consuming to know which context a given log file belongs to.

Here is what this change looks like in CI:
https://ci.jenkins.io/blue/organizations/jenkins/Infra%2Fevergreen/detail/PR-125/18/artifacts

![image](https://user-images.githubusercontent.com/223853/42183573-9ec738e8-7e42-11e8-9b15-83ff8b5037f6.png)
