### PR TITLE
Add timestamping to build logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     options {
         timeout(time: 1, unit: 'HOURS')
         buildDiscarder(logRotator(daysToKeepStr: '10'))
+        timestamps()
     }
 
     triggers {


### PR DESCRIPTION
This would, for instance, have greatly helped me understand where we are currently spending 1+ hour to build the whole pipeline, when `make check` takes <15 minutes on my laptop. 

Example on https://github.com/jenkins-infra/evergreen/pull/128