### PR TITLE
Build just once a day

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 
     triggers {
         pollSCM('H * * * *')
-        cron('H */6 * * *')
+        cron('H H * * *')
     }
 
     stages {


### PR DESCRIPTION
The current settings also post on PRs every 6 hours a failure message
when they are failing. We do not really need such a high frequency IMO,
~once a day on master was the main idea for this addition to catch
issues earlier.