### PR TITLE
[JENKINS-52471] Reintroduce npm installation

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u171-jre-alpine3.7
 
 ARG user=jenkins
 ARG group=jenkins

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u171-jre-alpine3.7
+FROM openjdk:8u171-jre-alpine3.8
 
 ARG user=jenkins
 ARG group=jenkins
@@ -53,6 +53,7 @@ RUN apk add --no-cache git \
                         bash \
                         supervisor \
                         nodejs \
+                        nodejs-npm \
                         ttf-dejavu \
                         curl \
                         socat

--- a/distribution/tests/offline-tests.sh
+++ b/distribution/tests/offline-tests.sh
@@ -49,6 +49,10 @@ test_npm_5_plus() {
   result=$( docker exec "$container_under_test" npm --version )
   assertEquals "5." "${result:0:2}"
 }
+test_node_version() {
+  result=$( docker exec "$container_under_test" node --version )
+  assertEquals "v8." "${result:0:3}"
+}
 
 # Ensure that we can successfully connect to only Let's Encrypt authorized
 # sites. See JEP-307


### PR DESCRIPTION
[JENKINS-52471](https://issues.jenkins-ci.org/browse/JENKINS-52471)

In latest Alpine distro, and in the last `nodejs` package release, the `nodejs-npm` package is no longer a transitive dependency for `nodejs`, and was released only a few hours/days ago. Hence our builds started failing when `npm` was missing from our images.

WIP