### PR TITLE
Move the skip logic to unit itself

### DIFF
--- a/distribution/client/Makefile
+++ b/distribution/client/Makefile
@@ -9,12 +9,12 @@ fix-formatting: depends
 	$(NODE) npm run eslint -- --fix
 
 check: lint
-	if [ -z "$${SKIP_TESTS}" ]; then \
-		$(MAKE) unit; \
-	fi;
+	$(MAKE) unit
 
 unit: depends
-	$(NODE) npm run jest
+	if [ -z "$${SKIP_TESTS}" ]; then \
+		$(NODE) npm run jest; \
+	fi;
 
 debug-unit: depends
 	$(NODE) node --inspect-brk=0.0.0.0:9229 node_modules/.bin/jest --runInBand --bail --forceExit test/


### PR DESCRIPTION
This way, tests will be skipped if the variable is defined, and `make unit` is triggered. Which is the case for instance from `make container-check`.

In that last case, this allows us to skip node tests when we're focusing on pure container related tests.