### PR TITLE
Use pipeline-github-notify-step plugin to make feedback quicker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,16 +108,16 @@ pipeline {
                 stage('Base image') {
                   agent { label 'linux' }
                   steps {
-                      githubNotify context: 'base-container-check', description: 'base-container-check', status: 'PENDING'
+                      githubNotify context: 'container-check/base', description: 'base-container-check', status: 'PENDING'
                       sh 'make -C distribution base-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
-                      success  { githubNotify context: 'base-container-check', description: 'base-container-check', status: 'SUCCESS' }
-                      failure  { githubNotify context: 'base-container-check', description: 'base-container-check', status: 'FAILURE' }
-                      unstable { githubNotify context: 'base-container-check', description: 'base-container-check', status: 'FAILURE' }
+                      success  { githubNotify context: 'container-check/base', description: 'base-container-check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'container-check/base', description: 'base-container-check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'container-check/base', description: 'base-container-check', status: 'FAILURE' }
                   }
                 }
                 stage('Docker Cloud image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,11 @@ pipeline {
         }
 
         stage('Build images') {
+            post {
+                success  { githubNotify context: 'build-images', description: 'Build Docker images', status: 'SUCCESS' }
+                failure  { githubNotify context: 'build-images', description: 'Build Docker images', status: 'FAILURE' }
+                unstable { githubNotify context: 'build-images', description: 'Build Docker images', status: 'FAILURE' }
+            }
             parallel {
 
                 stage('jenkins/evergreen') {
@@ -81,13 +86,8 @@ pipeline {
                         SKIP_TESTS = 'true'
                     }
                     steps {
-                        githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'PENDING'
+                        githubNotify context: 'build-images', description: 'Build Docker images', status: 'PENDING'
                         sh 'make -C distribution container'
-                    }
-                    post {
-                        success  { githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'SUCCESS' }
-                        failure  { githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'FAILURE' }
-                        unstable { githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'FAILURE' }
                     }
                 }
 
@@ -97,13 +97,7 @@ pipeline {
                         SKIP_TESTS = 'true'
                     }
                     steps {
-                        githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'PENDING'
                         sh 'make -C services container'
-                    }
-                    post {
-                        success  { githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'SUCCESS' }
-                        failure  { githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'FAILURE' }
-                        unstable { githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'FAILURE' }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,28 +26,28 @@ pipeline {
 
         stage('Lint code') {
           steps {
-              githubNotify context: 'lint', description: 'make lint', status: 'PENDING'
+              githubNotify context: 'checks/lint', description: 'make lint', status: 'PENDING'
               sh 'make lint'
           }
           post {
-              success  { githubNotify context: 'lint', description: 'make lint', status: 'SUCCESS' }
-              failure  { githubNotify context: 'lint', description: 'make lint', status: 'FAILURE' }
-              unstable { githubNotify context: 'lint', description: 'make lint', status: 'FAILURE' }
+              success  { githubNotify context: 'checks/lint', description: 'make lint', status: 'SUCCESS' }
+              failure  { githubNotify context: 'checks/lint', description: 'make lint', status: 'FAILURE' }
+              unstable { githubNotify context: 'checks/lint', description: 'make lint', status: 'FAILURE' }
           }
         }
 
         stage('Verifications') {
             post {
-                success  { githubNotify context: 'verifications', description: 'NodeJS Checks', status: 'SUCCESS' }
-                failure  { githubNotify context: 'verifications', description: 'NodeJS Checks', status: 'FAILURE' }
-                unstable { githubNotify context: 'verifications', description: 'NodeJS Checks', status: 'FAILURE' }
+                success  { githubNotify context: 'checks/node', description: 'NodeJS Checks', status: 'SUCCESS' }
+                failure  { githubNotify context: 'checks/node', description: 'NodeJS Checks', status: 'FAILURE' }
+                unstable { githubNotify context: 'checks/node', description: 'NodeJS Checks', status: 'FAILURE' }
             }
             parallel {
                 stage('Evergreen Client') {
                     steps {
                         // notification not purely related to here, but there's no proper way with
                         // Declarative to run something before all parallel stages.
-                        githubNotify context: 'verifications', description: 'NodeJS Checks', status: 'PENDING'
+                        githubNotify context: 'checks/node', description: 'NodeJS Checks', status: 'PENDING'
                         sh 'make -C distribution/client check'
                     }
                     post {
@@ -74,9 +74,9 @@ pipeline {
 
         stage('Build images') {
             post {
-                success  { githubNotify context: 'build-images', description: 'Build Docker images', status: 'SUCCESS' }
-                failure  { githubNotify context: 'build-images', description: 'Build Docker images', status: 'FAILURE' }
-                unstable { githubNotify context: 'build-images', description: 'Build Docker images', status: 'FAILURE' }
+                success  { githubNotify context: 'images/build', description: 'Build Docker images', status: 'SUCCESS' }
+                failure  { githubNotify context: 'images/build', description: 'Build Docker images', status: 'FAILURE' }
+                unstable { githubNotify context: 'images/build', description: 'Build Docker images', status: 'FAILURE' }
             }
             parallel {
 
@@ -86,7 +86,7 @@ pipeline {
                         SKIP_TESTS = 'true'
                     }
                     steps {
-                        githubNotify context: 'build-images', description: 'Build Docker images', status: 'PENDING'
+                        githubNotify context: 'images/build', description: 'Build Docker images', status: 'PENDING'
                         sh 'make -C distribution container'
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,31 +123,31 @@ pipeline {
                 stage('Docker Cloud image') {
                   agent { label 'linux' }
                   steps {
-                      githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'PENDING'
+                      githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'PENDING'
                       sh 'make -C distribution docker-cloud-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
-                      success  { githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'SUCCESS' }
-                      failure  { githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'FAILURE' }
-                      unstable { githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'FAILURE' }
+                      success  { githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'FAILURE' }
                   }
                 }
                 stage('AWS Cloud image (smokes)') {
                   agent { label 'linux' }
                   steps {
-                      githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'PENDING'
+                      githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'PENDING'
                       sh 'make -C distribution aws-cloud-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
-                      success  { githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'SUCCESS' }
-                      failure  { githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'FAILURE' }
-                      unstable { githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'FAILURE' }
+                      success  { githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'FAILURE' }
                   }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,13 @@ pipeline {
 
         stage('Lint code') {
           steps {
+              githubNotify context: 'lint', description: 'make lint', status: 'PENDING'
               sh 'make lint'
+          }
+          post {
+              success  { githubNotify context: 'lint', description: 'make lint', status: 'SUCCESS' }
+              failure  { githubNotify context: 'lint', description: 'make lint', status: 'FAILURE' }
+              unstable { githubNotify context: 'lint', description: 'make lint', status: 'FAILURE' }
           }
         }
 
@@ -34,25 +40,33 @@ pipeline {
             parallel {
                 stage('Evergreen Client') {
                     steps {
+                        githubNotify context: 'client-check', description: 'Evergreen Client Check', status: 'PENDING'
                         sh 'make -C distribution/client check'
                     }
                     post {
                         success {
                             archiveArtifacts 'distribution/client/coverage/**'
+                            githubNotify context: 'client-check', description: 'Evergreen Client Check', status: 'SUCCESS'
                         }
+                        failure  { githubNotify context: 'client-check', description: 'Evergreen Client Check', status: 'FAILURE' }
+                        unstable { githubNotify context: 'client-check', description: 'Evergreen Client Check', status: 'FAILURE' }
                     }
                 }
                 stage('Backend Services') {
                     steps {
+                        githubNotify context: 'backend-check', description: 'Evergreen Backend Check', status: 'PENDING'
                         sh 'make -C services check'
                     }
                     post {
                         success {
                             archiveArtifacts 'services/coverage/**'
+                            githubNotify context: 'backend-check', description: 'Evergreen Backend Check', status: 'SUCCESS'
                         }
                         cleanup {
                             sh 'make -C services stop'
                         }
+                        failure  { githubNotify context: 'backend-check', description: 'Evergreen Backend Check', status: 'FAILURE' }
+                        unstable { githubNotify context: 'backend-check', description: 'Evergreen Backend Check', status: 'FAILURE' }
                     }
                 }
             }
@@ -67,7 +81,13 @@ pipeline {
                         SKIP_TESTS = 'true'
                     }
                     steps {
+                        githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'PENDING'
                         sh 'make -C distribution container'
+                    }
+                    post {
+                        success  { githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'SUCCESS' }
+                        failure  { githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'FAILURE' }
+                        unstable { githubNotify context: 'build-evergreen', description: 'jenkins/evergreen build', status: 'FAILURE' }
                     }
                 }
 
@@ -77,7 +97,13 @@ pipeline {
                         SKIP_TESTS = 'true'
                     }
                     steps {
+                        githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'PENDING'
                         sh 'make -C services container'
+                    }
+                    post {
+                        success  { githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'SUCCESS' }
+                        failure  { githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'FAILURE' }
+                        unstable { githubNotify context: 'build-evergreen-backend', description: 'jenkinsciinfra/evergreen-backend build', status: 'FAILURE' }
                     }
                 }
             }
@@ -88,34 +114,46 @@ pipeline {
                 stage('Base image') {
                   agent { label 'linux' }
                   steps {
+                      githubNotify context: 'base-container-check', description: 'base-container-check', status: 'PENDING'
                       sh 'make -C distribution base-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
+                      success  { githubNotify context: 'base-container-check', description: 'base-container-check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'base-container-check', description: 'base-container-check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'base-container-check', description: 'base-container-check', status: 'FAILURE' }
                   }
                 }
                 stage('Docker Cloud image') {
                   agent { label 'linux' }
                   steps {
+                      githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'PENDING'
                       sh 'make -C distribution docker-cloud-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
+                      success  { githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'docker-cloud-container-check', description: 'docker-cloud-container-check', status: 'FAILURE' }
                   }
                 }
                 stage('AWS Cloud image (smokes)') {
                   agent { label 'linux' }
                   steps {
+                      githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'PENDING'
                       sh 'make -C distribution aws-cloud-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
+                      success  { githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'aws-cloud-container-check', description: 'aws-cloud-container-check', status: 'FAILURE' }
                   }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,31 +123,31 @@ pipeline {
                 stage('Docker Cloud image') {
                   agent { label 'linux' }
                   steps {
-                      githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'PENDING'
+                      githubNotify context: 'container-check/docker-cloud', description: 'Docker Cloud Flavor check', status: 'PENDING'
                       sh 'make -C distribution docker-cloud-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
-                      success  { githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'SUCCESS' }
-                      failure  { githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'FAILURE' }
-                      unstable { githubNotify context: 'docker-cloud-container-check', description: 'Docker Cloud Flavor check', status: 'FAILURE' }
+                      success  { githubNotify context: 'container-check/docker-cloud', description: 'Docker Cloud Flavor check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'container-check/docker-cloud', description: 'Docker Cloud Flavor check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'container-check/docker-cloud', description: 'Docker Cloud Flavor check', status: 'FAILURE' }
                   }
                 }
                 stage('AWS Cloud image (smokes)') {
                   agent { label 'linux' }
                   steps {
-                      githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'PENDING'
+                      githubNotify context: 'container-check/aws-cloud', description: 'AWS Cloud Flavor check', status: 'PENDING'
                       sh 'make -C distribution aws-cloud-container-check'
                   }
                   post {
                       always {
                           archiveArtifacts artifacts: '**/build/tests-run*/**.log*'
                       }
-                      success  { githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'SUCCESS' }
-                      failure  { githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'FAILURE' }
-                      unstable { githubNotify context: 'aws-cloud-container-check', description: 'AWS Cloud Flavor check', status: 'FAILURE' }
+                      success  { githubNotify context: 'container-check/aws-cloud', description: 'AWS Cloud Flavor check', status: 'SUCCESS' }
+                      failure  { githubNotify context: 'container-check/aws-cloud', description: 'AWS Cloud Flavor check', status: 'FAILURE' }
+                      unstable { githubNotify context: 'container-check/aws-cloud', description: 'AWS Cloud Flavor check', status: 'FAILURE' }
                   }
                 }
             }


### PR DESCRIPTION
Analyzing the failure cause can be a bit time-consuming. I have used https://plugins.jenkins.io/pipeline-githubnotify-step successfully in the past for enriching the PR statuses, and understand quicker what went wrong.

I am totally aware this adds quite some verbosity in the `Jenkinsfile`, but I think it's OK and is going to be pretty helpful.

**WIP**