### PR TITLE
Download timing

### DIFF
--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -15,6 +15,7 @@ lint: shunit2
 	../tools/yamllint -s config/as-code/*.yaml
 	../tools/shellcheck -x tests/tests.sh
 	$(MAKE) -C environments lint
+	$(MAKE) -C client lint
 
 check: lint
 	$(MAKE) -C client $@

--- a/distribution/client/src/lib/downloader.js
+++ b/distribution/client/src/lib/downloader.js
@@ -15,6 +15,14 @@ class Downloader {
   constructor() {
   }
 
+  static formatDuration(durationInMs) {
+    if (durationInMs < 1000) {
+      return `${durationInMs}ms`;
+    }
+    const seconds = Math.floor(durationInMs / 1000);
+    const millisecs = durationInMs - 1000 * seconds;
+    return `${seconds}.${millisecs}s`;
+  }
   static download(item, dir) {
     const itemUrl = url.parse(item);
     const itemUrlBaseName = path.basename(itemUrl.pathname);
@@ -41,9 +49,13 @@ class Downloader {
       retry: 3 // make it configurable?
     };
 
+    const startTime = Date.now();
     return new Promise( (resolve, reject) => {
       rp(options)
         .then( (response) => {
+
+          const elapsedString = Downloader.formatDuration(Date.now() - startTime);
+          logger.info  ('Download complete for', filename, `(Took ${elapsedString})`);
 
           const output = fs.createWriteStream(filename);
 

--- a/distribution/client/src/lib/update.js
+++ b/distribution/client/src/lib/update.js
@@ -96,7 +96,7 @@ class Update {
    * message
    */
   async fetchTo(url, outputPath) {
-    return Downloader.download(url, outputPath).then(s => logger.info('Download complete', s.path));
+    return Downloader.download(url, outputPath);
   }
 
   getCurrentLevel() {


### PR DESCRIPTION
Adds a small log to help see how much time a given download took:

Example excerpt using `make run`:
```
instance_1  | info: Download complete for /evergreen/jenkins/home/plugins/essentials-0.3-rc20.a3f76cdd1348.hpi (Took 335ms)
instance_1  | info: Download complete for /evergreen/jenkins/home/plugins/configuration-as-code-0.11-alpha-rc362.942711740b07.hpi (Took 922ms)
instance_1  | info: Download complete for /evergreen/jenkins/home/plugins/blueocean.hpi (Took 4.678s)
instance_1  | info: Download complete for /evergreen/jenkins/home/plugins/blueocean-commons.hpi (Took 4.879s)
instance_1  | info: Download complete for /evergreen/jenkins/home/plugins/blueocean-pipeline-api-impl.hpi (Took 4.993s)
```