### PR TITLE
Reenable download logs during tests and development

### DIFF
--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     build: ./
     environment:
       - 'EVERGREEN_ENDPOINT=http://backend:3030'
+      - 'LOG_LEVEL=info'
     ports:
       - '8080:8080'
     depends_on:


### PR DESCRIPTION
The min log level got bumped to warn around a week ago. Hence for instance we do not have the plugins downloading logs anymore, which is pretty handy during dev to understand what may be going wrong.

---

This is probably why I was surprised a few days ago to see some logs from @mandie722 where a WAR would be found, but no logs showing it was able to be downloaded. Most likely this was actually the reason: it was downloading correctly, but just we weren't seeing any log about this anymore.