### PR TITLE
[JENKINS-52582] Use public AMI and configure using user data scripts

### DIFF
--- a/distribution/environments/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/environments/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -28,7 +28,7 @@
     "EC2EssentialsInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
-        "ImageId": "ami-0b32af9c4a966ea17",
+        "ImageId": "ami-cfe4b2b0",
         "InstanceType": {"Ref": "InstanceTypeParameter"},
         "IamInstanceProfile": {"Ref": "MasterInstanceProfile"},
         "BlockDeviceMappings": [
@@ -50,10 +50,16 @@
           "Fn::Base64" : {
             "Fn::Join" : ["", [
               "#!/bin/bash -v\n",
+              "# Install Docker to be able to start the Jenkins Essentials container\n",
+              "sudo yum update -y\n",
+              "sudo yum install -y docker\n",
+              "sudo service docker start\n",
+              "sudo usermod -a -G docker ec2-user # not strictly necessary\n",
+              "# Now the Essentials specific part\n",
               "export DOCKER_IMAGE=jenkins/evergreen:aws-ec2-cloud\n",
               "echo \"", { "Ref": "PrivateKey"}, "\" > ssh-agents-private-key\n",
-              "docker pull $DOCKER_IMAGE\n",
-              "docker run -d -p 8080:8080 -p 50000:50000 ",
+              "sudo docker pull $DOCKER_IMAGE\n",
+              "sudo docker run -d -p 8080:8080 -p 50000:50000 ",
               " --name jenkins-essentials",
               " -e EVERGREEN_ENDPOINT=http://evergreen.jenkins.io.batmat.net:8080",
               " -v $PWD/ssh-agents-private-key:/run/secrets/PRIVATE_KEY:ro",

--- a/distribution/environments/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
+++ b/distribution/environments/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
@@ -10,13 +10,19 @@ jenkins:
         privateKey: "${PRIVATE_KEY}"
         templates:
           - description: "EC2 Agent"
-            ami: "ami-032b0a5293352ac96"
+            ami: "ami-cfe4b2b0"
             labelString: "agent"
             type: "T2Xlarge"
             securityGroups: "${AGENT_SECURITY_GROUP}"
             remoteFS: "/home/ec2-user"
             remoteAdmin: "ec2-user"
             # FIXME: JENKINS-52319: without this, NPE during provisioning
-            userData: ""
+            userData: >
+              sudo yum update -y;
+              sudo yum remove -y java-1.7.0-openjdk ;
+              sudo yum install -y docker java-1.8.0-openjdk-devel;
+              sudo service docker start;
+              sudo usermod -a -G docker ec2-user;
+              sudo docker info;
             # FIXME: JENKINS-52334: mode *required*, broken if missing.
             mode: NORMAL


### PR DESCRIPTION
[JENKINS-52582](https://issues.jenkins-ci.org/browse/JENKINS-52582)

So as agreed, now using the most official and common AMI I could find, maintained by AWS: `ami-cfe4b2b0`.

We now use it for both the _Master_ and _agents_, but using custom init script to install the packages we need in both situations (i.e. Docker for both, plus Java 8 only for agents).

