### PR TITLE
Capture the important dependency information associated with each build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,18 @@ pipeline {
           }
         }
 
+        stage('Confirm Dependencies') {
+            steps {
+                sh 'make -C services generate-ingest'
+            }
+            post {
+                success {
+                    archiveArtifacts artifacts: 'services/ingest.json', fingerprint: true
+                    archiveArtifacts artifacts: 'services/essentials.yaml', fingerprint: true
+                }
+            }
+        }
+
         stage('Verifications') {
             parallel {
                 stage('Evergreen Client') {


### PR DESCRIPTION
ingest.json is not going to be changing unless essentials.yaml has changed, but
I want both of them to always be present with any given build for forensics.