### PR TITLE
Ensure that out-of-sync essentials.yaml specs cannot be committed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,14 +30,29 @@ pipeline {
           }
         }
 
-        stage('Confirm Dependencies') {
+        stage('Validate essentials.yaml') {
+            steps {
+                dir('services') {
+                    sh 'make generate-essentials && git diff --quiet essentials.yaml'
+                }
+            }
+            post {
+                failure {
+                    echo 'Please ensure that updates to essentials.yaml are committed!'
+                }
+                always {
+                    archiveArtifacts artifacts: 'services/essentials.yaml', fingerprint: true
+                }
+            }
+        }
+
+        stage('Prepare ingest') {
             steps {
                 sh 'make -C services generate-ingest'
             }
             post {
                 success {
                     archiveArtifacts artifacts: 'services/ingest.json', fingerprint: true
-                    archiveArtifacts artifacts: 'services/essentials.yaml', fingerprint: true
                 }
             }
         }

--- a/services/Makefile
+++ b/services/Makefile
@@ -88,6 +88,7 @@ container-migration: Dockerfile.migrations
 	docker build -t $(IMAGE_NAME)-migrations:$(IMAGE_TAG) -f Dockerfile.migrations .
 
 generate-essentials: essentials.yaml prepare-essentials
+	wget -O update-center.json https://updates.jenkins.io/update-center.actual.json
 	node ./prepare-essentials save
 
 generate-ingest: essentials.yaml prepare-essentials
@@ -97,6 +98,7 @@ clean:
 	$(COMPOSE) down || true
 	rm -rf node_modules
 	rm -f $(DB_DUMP)
+	rm -f update-center.json
 	docker rmi $$(docker images -q -f "reference=$(IMAGE_NAME)") || true
 
 publish: container


### PR DESCRIPTION
This means that spec and status must always be in sync in the tree. :+1:

Fixes JENKINS-53041