### PR TITLE
Force the reconnect on the evergreen-client socket.io connection

### DIFF
--- a/distribution/client/src/client.js
+++ b/distribution/client/src/client.js
@@ -99,7 +99,12 @@ class Client {
     this.app.configure(restClient.fetch(fetch));
 
     logger.info('Configuring the client for socket.io off %s', endpoint);
-    this.socket = io(process.env.EVERGREEN_ENDPOINT);
+    this.socket = io(process.env.EVERGREEN_ENDPOINT, {
+      reconnection: true,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax : 5000,
+      reconnectionAttempts: Infinity
+    });
     const socketApp = feathers();
     socketApp.configure(socketio(this.socket));
 


### PR DESCRIPTION
From my read on the socket.io 2 documentation, the reconnection to infinity
should be the default, but in practice that does not appear to be the case.

Tested this locally by killing the server for about ten minutes and then
bringing it back. Once the server was back online, the client reconnects and
receives the pings appropriately

Should fix JENKINS-53057