### PR TITLE
10 second timeouts are too short for downloading plugins/core

### DIFF
--- a/distribution/client/src/lib/downloader.js
+++ b/distribution/client/src/lib/downloader.js
@@ -53,8 +53,8 @@ class Downloader {
       simple: true,
       resolveWithFullResponse: true,
       encoding: null,
-      timeout: 10 * 1000,
-      retry: 3 // make it configurable?
+      timeout: 120 * 1000,
+      retry: 10
     };
 
     const startTime = Date.now();


### PR DESCRIPTION
Sticking with the standard HTTP 120s, with more retries