### PR TITLE
Support tainting update levels with a PATCH method

### DIFF
--- a/services/src/services/update/update.class.js
+++ b/services/src/services/update/update.class.js
@@ -21,10 +21,14 @@ class Update extends FeathersSequelize.Service {
      * Undefining some APIs which we don't want/need.
      */
     this.update = undefined;
-    this.patch = undefined;
     this.remove = undefined;
   }
 
+  /*
+   * Return the latest update level for the given parameters
+   *
+   * Typically will not be called with an `id`, and is directly
+   */
   async get(id, params) {
     let findParams = {
       query: params.query, /* copy the original query parameters over */

--- a/services/test/services/update.hooks.test.js
+++ b/services/test/services/update.hooks.test.js
@@ -90,4 +90,43 @@ describe('update service hooks', () => {
       }).toThrow(errors.BadRequest);
     });
   });
+
+  describe('patchByCommitAndChannel', () => {
+    let find = jest.fn();
+    let context = {
+      data: {},
+      app: {
+        service: () => {
+          return {
+            find: find,
+          };
+        },
+      },
+    };
+
+    it('should look up based on commit and channel', () => {
+      find.mockResolvedValue(context);
+      expect(hooks.patchByCommitAndChannel(context)).resolves.toBe(context);
+      expect(find).toHaveBeenCalled();
+    });
+
+    it('should throw an error to the caller if there are more than one records', async () => {
+      find.mockResolvedValue([1, 2, 3]);
+      await expect(hooks.patchByCommitAndChannel(context)).rejects.toThrow(errors.GeneralError);
+      expect(find).toHaveBeenCalled();
+      expect.assertions(2);
+    });
+
+    it('should assign the discovered id if it has been found', async () => {
+      find.mockResolvedValue([
+        {
+          id: 1337,
+        }
+      ]);
+      await expect(hooks.patchByCommitAndChannel(context)).resolves.toBe(context);
+      expect(find).toHaveBeenCalled();
+      expect(context.data.id).toEqual(1337);
+      expect.assertions(3);
+    });
+  });
 });

--- a/services/views/index.ejs
+++ b/services/views/index.ejs
@@ -31,6 +31,9 @@
                 <thead class="thead-dark">
                     <tr>
                         <th>
+                            Status
+                        </th>
+                        <th>
                             Created At
                         </th>
                         <th>
@@ -51,10 +54,21 @@
                               Record:   <%= update.id %>
                             -->
                             <td align="center">
+                                <% if (update.tainted) { %>
+                                    <div class="alert alert-danger" role="alert">
+                                        tainted
+                                    </div>
+                                <% } else { %>
+                                    <div class="alert alert-success" role="alert">
+                                        available
+                                    </div>
+                                <% } %>
+                            </td>
+                            <td align="center">
                                 <%= update.createdAt %>
                             </td>
                             <td>
-                                <a href="https://github.com/jenkins-infra/evergreen/commit/<%= update.commit %>" target="_blank">
+                                <a href="https://github.com/jenkins-infra/evergreen/blob/<%= update.commit %>/services/essentials.yaml" target="_blank">
                                 <%= update.commit %>
                                 </a>
                             </td>


### PR DESCRIPTION
This will only be used by the behind-the-scenes API tooling

Related to JENKINS-53040