### PR TITLE
Bump the config-file-provider and github-branch-source plugins to latest

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -16,6 +16,9 @@ spec:
       artifactId: blueocean
       version: 1.8.2
     - groupId: org.jenkins-ci.plugins
+      artifactId: config-file-provider
+      version: '2.18'
+    - groupId: org.jenkins-ci.plugins
       artifactId: credentials-binding
       version: '1.16'
     - groupId: org.jenkins-ci.plugins
@@ -33,6 +36,9 @@ spec:
     - groupId: com.coravy.hudson.plugins.github
       artifactId: github
       version: 1.29.2
+    - groupId: org.jenkins-ci.plugins
+      artifactId: github-branch-source
+      version: 2.3.6
     - groupId: org.jenkins-ci.plugins
       artifactId: htmlpublisher
       version: '1.16'
@@ -188,7 +194,7 @@ status:
       version: 1.3.1
     - groupId: org.jenkins-ci.plugins
       artifactId: config-file-provider
-      version: 2.15.4
+      version: '2.18'
     - groupId: io.jenkins
       artifactId: configuration-as-code
       version: 0.11-alpha-rc362.942711740b07
@@ -236,7 +242,7 @@ status:
       version: '1.90'
     - groupId: org.jenkins-ci.plugins
       artifactId: github-branch-source
-      version: 2.3.2
+      version: 2.3.6
     - groupId: org.jenkins-ci.ui
       artifactId: handlebars
       version: '1.1'


### PR DESCRIPTION
These two specifically have outstanding security advisories