### PR TITLE
[JENKINS-53190] Only generate admin password for the first startup

### DIFF
--- a/distribution/scripts/jenkins-evergreen.sh
+++ b/distribution/scripts/jenkins-evergreen.sh
@@ -5,13 +5,17 @@ set -euo pipefail
 passwordFileLocation="$JENKINS_HOME/secrets/initialAdminPassword"
 passwordFileLocationDirectory="$( dirname "$passwordFileLocation" )"
 
-echo -n "Creating $passwordFileLocationDirectory... "
-mkdir -p "$passwordFileLocationDirectory"
-echo "Done."
+generateNewAdminPassword() {
+  echo -n "Creating $passwordFileLocationDirectory... "
+  mkdir -p "$passwordFileLocationDirectory"
+  echo "Done."
 
-echo -n "Generating admin password... "
-echo $RANDOM | md5sum | cut -d ' ' -f 1 > "$passwordFileLocation"
-echo "Done. Password value stored in $passwordFileLocation file."
+  echo -n "Generating admin password... "
+  echo $RANDOM | md5sum | cut -d ' ' -f 1 > "$passwordFileLocation"
+  echo "Done. Password value stored in $passwordFileLocation file."
+}
+
+generateNewAdminPassword
 
 JENKINS_ADMIN_PASSWORD="$( cat "$passwordFileLocation" )"
 

--- a/distribution/scripts/jenkins-evergreen.sh
+++ b/distribution/scripts/jenkins-evergreen.sh
@@ -15,7 +15,11 @@ generateNewAdminPassword() {
   echo "Done. Password value stored in $passwordFileLocation file."
 }
 
-generateNewAdminPassword
+if [[ -f $passwordFileLocation ]]; then
+  echo "Password file already exists, not generating a new one."
+else
+  generateNewAdminPassword
+fi
 
 JENKINS_ADMIN_PASSWORD="$( cat "$passwordFileLocation" )"
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-53190 found by @rsandell earlier today

(We need to add automated tests of the full cycle like we do for first startup. I've been thinking about putting the acceptance testing we currently do with `shUnit2` under the distribution/tests directory into some higher level directory under the root or so. I think I will do that soon).