### PR TITLE
Automatically check for updates whenever the socket.io channel reconnects

### DIFF
--- a/distribution/client/src/client.js
+++ b/distribution/client/src/client.js
@@ -119,6 +119,11 @@ class Client {
       logger.debug('Received ping', message);
     });
 
+    this.socket.on('reconnect', () => {
+      logger.info('Reconnecting the socket.io channel, and checking for updates');
+      this.runUpdates();
+    });
+
     this.reg.register().then((res, newRegistration) => {
       logger.debug('Registration returned', res);
       this.status.authenticate(this.reg.uuid, this.reg.token);


### PR DESCRIPTION
This will ensure that if we missed an event from the backend, that we'll be able
to catch up when we come back online

Fixes JENKINS-53123