### PR TITLE
Upgrade to the latest Node LTS and npm

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u171-jre-alpine3.8
+FROM node:9-alpine
 
 ARG user=jenkins
 ARG group=jenkins
@@ -52,12 +52,15 @@ RUN apk add --no-cache git \
                         openssh-client \
                         unzip \
                         bash \
+                        openjdk8 \
                         supervisor \
-                        nodejs \
-                        nodejs-npm \
                         ttf-dejavu \
                         curl \
-                        socat
+                        socat \
+                        wget
+
+# Ensure the latest npm is available
+RUN npm install npm@latest -g
 
 # TODO: add a checksum check?
 RUN cd /tmp && \
@@ -72,8 +75,9 @@ COPY config/logging.properties $EVERGREEN_HOME/logging.properties
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
 # ensure you use the same uid
-RUN addgroup -g ${gid} ${group} \
-    && adduser -h "$JENKINS_HOME" -u ${uid} -G ${group} -s /bin/bash -D ${user}
+RUN deluser node && \
+    addgroup -g ${gid} ${group} && \
+    adduser -h "$JENKINS_HOME" -u ${uid} -G ${group} -s /bin/bash -D ${user}
 
 
 # Ensure that only the right CA root certificates are present on the system

--- a/distribution/config/supervisord.conf
+++ b/distribution/config/supervisord.conf
@@ -8,7 +8,7 @@ port=:9001
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:evergreen-client]
-command=/usr/bin/npm run client
+command=/usr/local/bin/npm run client
 directory=%(ENV_EVERGREEN_HOME)s/client
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/distribution/environments/docker-cloud/config/supervisord.conf
+++ b/distribution/environments/docker-cloud/config/supervisord.conf
@@ -8,7 +8,7 @@ port=:9001
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:evergreen-client]
-command=/usr/bin/npm run client
+command=/usr/local/bin/npm run client
 directory=%(ENV_EVERGREEN_HOME)s/client
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/distribution/tests/offline-tests.sh
+++ b/distribution/tests/offline-tests.sh
@@ -47,11 +47,11 @@ test_not_root() {
 # https://github.com/jenkins-infra/evergreen/pull/60#discussion_r182666012
 test_npm_5_plus() {
   result=$( docker exec "$container_under_test" npm --version )
-  assertEquals "Result should be 5." "5." "${result:0:2}"
+  assertEquals "Result should be 6." "6." "${result:0:2}"
 }
 test_node_version() {
   result=$( docker exec "$container_under_test" node --version )
-  assertEquals "Result should be v8." "v8." "${result:0:3}"
+  assertEquals "Result should be v9." "v9." "${result:0:3}"
 }
 
 # Ensure that we can successfully connect to only Let's Encrypt authorized


### PR DESCRIPTION
This switches the base container to allow us to get the absolute latest and
greatest Node LTS, since the Alpine packages are too old. Additionally, Alpine's
ld and libc are sufficiently different to where Node's distributable binaries
are not capable of running against them.

Fixes JENKINS-54166