### PR TITLE
Don't intentionally override already computed plugins to pass back to the client

### DIFF
--- a/services/acceptance/update-versions.test.js
+++ b/services/acceptance/update-versions.test.js
@@ -14,22 +14,6 @@ describe('versions/updates interaction acceptance tests', () => {
   afterAll(done => h.stopApp(done));
 
   beforeEach(async () => {
-    let { token, uuid } = await h.registerAndAuthenticate();
-    this.token = token;
-    this.uuid = uuid;
-
-    /*
-     * Once we have registered, we need to send a status in order for updates
-     * to properly be loaded.
-     */
-    await request({
-      url: h.getUrl('/status'),
-      method: 'POST',
-      headers: { 'Authorization': this.token },
-      json: true,
-      body: { uuid: this.uuid, flavor: 'docker-cloud' }
-    });
-
     /*
      * We always want to make sure we have a properly seeded database with the
      * latest from ingest.yaml for each test.
@@ -49,118 +33,183 @@ describe('versions/updates interaction acceptance tests', () => {
     });
   });
 
-  describe('fetching updates for a fresh client', () => {
+  describe('with a docker-cloud flavored client', () => {
     beforeEach(async () => {
-      this.response = await request({
-        url: h.getUrl(`/update/${this.uuid}`),
-        headers: { 'Authorization': this.token },
-        json: true
-      });
-    });
+      let { token, uuid } = await h.registerAndAuthenticate();
+      this.token = token;
+      this.uuid = uuid;
 
-    it('should be in the `general` channel', () => {
-      expect(this.response).toHaveProperty('meta.channel', 'general');
-    });
-
-    it('should have a core url', () => {
-      expect(this.response).toHaveProperty('core.url');
-    });
-
-    it('should have plugins', () => {
-      expect(this.response).toHaveProperty('plugins.updates');
-      expect(this.response.plugins.updates.length).toBeGreaterThan(0);
-    });
-
-    describe('a follow-up request for updates', () => {
-      it('should receive a 304 Not Modified response', () => {
-        return request({
-          url: h.getUrl(`/update/${this.uuid}`),
-          headers: { 'Authorization': this.token },
-          qs: {
-            level: this.response.meta.level,
-          },
-          json: true
-        })
-          .then(r => expect(r).toBeFalsy())
-          .catch(err => expect(err.statusCode).toBe(304));
-      });
-    });
-  });
-
-  describe('fetching updates for a fresh client with a `docker-cloud` flavor', () => {
-    beforeEach(async () => {
-      this.response = await request({
-        url: h.getUrl(`/update/${this.uuid}`),
-        headers: { 'Authorization': this.token },
-        json: true
-      });
-    });
-
-    it('should include the docker-plugin', () => {
-      expect(this.response).toHaveProperty('plugins.updates');
-      let foundPlugin = false;
-      this.response.plugins.updates.forEach((plugin) => {
-        if (plugin.url.match(/docker-plugin/)) {
-          foundPlugin = true;
-        }
-      });
-      expect(foundPlugin).toBeTruthy();
-    });
-  });
-
-  describe('fetching updates for a client with `versions` records', () => {
-
-    beforeEach(async () => {
       /*
-       * First we need to publish a versions
-       */
-      let pluginManifest = this.ingest.plugins[0];
-      this.pluginName = pluginManifest.artifactId;
-
-      let versions = {
-        schema: 1,
-        container: {},
-        client: {},
-        jenkins: {
-          core: this.ingest.core.checksum.signature,
-          plugins: {},
-        },
-      };
-      versions.jenkins.plugins[this.pluginName] = pluginManifest.checksum.signature;
-
+      * Once we have registered, we need to send a status in order for updates
+      * to properly be loaded.
+      */
       await request({
-        url: h.getUrl('/versions'),
+        url: h.getUrl('/status'),
         method: 'POST',
         headers: { 'Authorization': this.token },
         json: true,
         body: {
           uuid: this.uuid,
-          manifest: versions
+          flavor: 'docker-cloud'
         }
-      });
-      this.response = await request({
-        url: h.getUrl(`/update/${this.uuid}`),
-        headers: { 'Authorization': this.token },
-        json: true
       });
     });
 
-    it('should not be given that core version as an update', () => {
-      expect(this.response).toBeTruthy();
-      expect(this.response).toHaveProperty('core', {});
+    describe('fetching updates for a fresh client', () => {
+      beforeEach(async () => {
+        this.response = await request({
+          url: h.getUrl(`/update/${this.uuid}`),
+          headers: { 'Authorization': this.token },
+          json: true
+        });
+      });
+
+      it('should be in the `general` channel', () => {
+        expect(this.response).toHaveProperty('meta.channel', 'general');
+      });
+
+      it('should have a core url', () => {
+        expect(this.response).toHaveProperty('core.url');
+      });
+
+      it('should have plugins', () => {
+        expect(this.response).toHaveProperty('plugins.updates');
+        expect(this.response.plugins.updates.length).toBeGreaterThan(0);
+      });
+
+      it('should include the docker-plugin', () => {
+        expect(this.response).toHaveProperty('plugins.updates');
+        let foundPlugin = false;
+        this.response.plugins.updates.forEach((plugin) => {
+          if (plugin.url.match(/docker-plugin/)) {
+            foundPlugin = true;
+          }
+        });
+        expect(foundPlugin).toBeTruthy();
+      });
+
+      describe('a follow-up request for updates', () => {
+        it('should receive a 304 Not Modified response', () => {
+          return request({
+            url: h.getUrl(`/update/${this.uuid}`),
+            headers: { 'Authorization': this.token },
+            qs: {
+              level: this.response.meta.level,
+            },
+            json: true
+          })
+            .then(r => expect(r).toBeFalsy())
+            .catch(err => expect(err.statusCode).toBe(304));
+        });
+      });
     });
 
-    it('should not be given a plugin it already has', () => {
-      expect(this.response).toBeTruthy();
-      expect(this.response).toHaveProperty('plugins.updates');
 
-      let found = false;
-      this.response.plugins.updates.forEach((plugin) => {
-        if (plugin.url.match(this.pluginName)) {
-          found = true;
-        }
+    describe('fetch updates for a client with empty `versions` records', () => {
+      beforeEach(async () => {
+        const versions = {
+          schema: 1,
+          container: {},
+          client: {},
+          jenkins: {
+            core: null,
+            plugins: {},
+          },
+        };
+
+        await request({
+          url: h.getUrl('/versions'),
+          method: 'POST',
+          headers: { 'Authorization': this.token },
+          json: true,
+          body: {
+            uuid: this.uuid,
+            manifest: versions
+          }
+        });
+
+        this.response = await request({
+          url: h.getUrl(`/update/${this.uuid}`),
+          headers: { 'Authorization': this.token },
+          json: true
+        });
       });
-      expect(found).not.toBeTruthy();
+
+      it('should be given that core version as an update', () => {
+        expect(this.response).toBeTruthy();
+        expect(this.response).toHaveProperty('core.url');
+      });
+
+      it('should have plugins', () => {
+        expect(this.response).toHaveProperty('plugins.updates');
+        expect(this.response.plugins.updates.length).toBeGreaterThan(0);
+      });
+
+      it('should include the docker-plugin', () => {
+        expect(this.response).toHaveProperty('plugins.updates');
+        let foundPlugin = false;
+        this.response.plugins.updates.forEach((plugin) => {
+          if (plugin.url.match(/docker-plugin/)) {
+            foundPlugin = true;
+          }
+        });
+        expect(foundPlugin).toBeTruthy();
+      });
+    });
+
+    describe('fetching updates for a client with filled out `versions` records', () => {
+      beforeEach(async () => {
+        /*
+        * First we need to publish a versions
+        */
+        let pluginManifest = this.ingest.plugins[0];
+        this.pluginName = pluginManifest.artifactId;
+
+        let versions = {
+          schema: 1,
+          container: {},
+          client: {},
+          jenkins: {
+            core: this.ingest.core.checksum.signature,
+            plugins: {},
+          },
+        };
+        versions.jenkins.plugins[this.pluginName] = pluginManifest.checksum.signature;
+
+        await request({
+          url: h.getUrl('/versions'),
+          method: 'POST',
+          headers: { 'Authorization': this.token },
+          json: true,
+          body: {
+            uuid: this.uuid,
+            manifest: versions
+          }
+        });
+        this.response = await request({
+          url: h.getUrl(`/update/${this.uuid}`),
+          headers: { 'Authorization': this.token },
+          json: true
+        });
+      });
+
+      it('should not be given that core version as an update', () => {
+        expect(this.response).toBeTruthy();
+        expect(this.response).toHaveProperty('core', {});
+      });
+
+      it('should not be given a plugin it already has', () => {
+        expect(this.response).toBeTruthy();
+        expect(this.response).toHaveProperty('plugins.updates');
+
+        let found = false;
+        this.response.plugins.updates.forEach((plugin) => {
+          if (plugin.url.match(this.pluginName)) {
+            found = true;
+          }
+        });
+        expect(found).not.toBeTruthy();
+      });
     });
   });
 });

--- a/services/src/services/update/update.class.js
+++ b/services/src/services/update/update.class.js
@@ -91,9 +91,7 @@ class Update extends FeathersSequelize.Service {
       computedManifest.core = {};
     }
 
-    if (Object.keys(latestClientVersion.manifest.jenkins.plugins).length === 0) {
-      computedManifest.plugins.updates = record.manifest.plugins;
-    } else {
+    if (Object.keys(latestClientVersion.manifest.jenkins.plugins).length != 0) {
       let signatures = Object.values(latestClientVersion.manifest.jenkins.plugins);
       let updates = [];
       record.manifest.plugins.forEach((plugin) => {


### PR DESCRIPTION
In the case where the client, with a flavor, had published an empty versions
manifest, the filterVersionsForClient function would override the already
computed plugins needed for that flavor with the base set of plugins.

This avoids that behavior by making the function no-op when there are no plugins
in the versions manifest.