### PR TITLE
[JENKINS-53286] Enable Sentry user capturing

### DIFF
--- a/services/src/libs/sentry.js
+++ b/services/src/libs/sentry.js
@@ -35,6 +35,7 @@ class Sentry {
         level: data.log.level.toLowerCase(),
         logger: data.log.name,
         extra: {
+          id: data.uuid,
           uuid: data.uuid,
           source: data.log
         }
@@ -44,6 +45,7 @@ class Sentry {
         level: data.log.level.toLowerCase(),
         logger: data.log.name,
         extra: {
+          id: data.uuid,
           uuid: data.uuid,
           source: data.log
         }


### PR DESCRIPTION
[JENKINS-53286](https://issues.jenkins-ci.org/browse/JENKINS-53286)

As documented in https://docs.sentry.io/learn/context/#capturing-the-user

I chose to just add another field `id` next to `uuid` to not disrupt too much the current behavior, just in case.
Likely, we might remove `uuid` later on if this proves to work nicely.