### PR TITLE
 [JENKINS-53285] Update plugins to latest to avoid warnings

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -90,12 +90,6 @@ spec:
     - groupId: org.jenkins-ci.main
       artifactId: maven-plugin
       version: 3.1.2
-    - groupId: org.jenkins-ci.plugins
-      artifactId: node-iterator-api
-      version: 1.5.0
-    - groupId: org.jenkins-ci.plugins
-      artifactId: run-condition
-      version: '1.0'
   environments:
     - name: docker-cloud
       plugins:

--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -69,6 +69,38 @@ spec:
     - groupId: io.jenkins.plugins
       artifactId: artifact-manager-s3
       version: '1.1'
+      # transitive dependencies that we want to force the upgrade of
+      # Note: it would be nice to have a way to fail the evergreen build if
+      # those things below are *not* already pulled in transitively and just
+      # the version is bumped
+    - groupId: org.jenkins-ci.plugins
+      artifactId: authentication-tokens
+      version: '1.3'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: conditional-buildstep
+      version: '1.3.6'
+    - groupId: org.jenkins-ci.plugins.icon-shim
+      artifactId: icon-shim
+      version: '2.0.3'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: javadoc
+      version: '1.4'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: jsch
+      version: '0.1.54.2'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: mapdb-api
+      version: '1.0.9.0'
+    - groupId: org.jenkins-ci.main
+      artifactId: maven-plugin
+      version: '3.1.2'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: node-iterator-api
+      version: '1.5.0'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: run-condition
+      version: '1.0'
+
   environments:
     - name: docker-cloud
       plugins:
@@ -101,7 +133,7 @@ status:
       version: '1.1'
     - groupId: org.jenkins-ci.plugins
       artifactId: authentication-tokens
-      version: '1.1'
+      version: '1.3'
     - groupId: org.jenkins-ci.plugins
       artifactId: aws-credentials
       version: '1.23'
@@ -251,7 +283,7 @@ status:
       version: '1.16'
     - groupId: org.jenkins-ci.plugins.icon-shim
       artifactId: icon-shim
-      version: 1.0.3
+      version: '2.0.3'
     - groupId: org.jenkins-ci.plugins
       artifactId: jackson2-api
       version: 2.8.11.2
@@ -293,7 +325,7 @@ status:
       version: '1.1'
     - groupId: org.jenkins-ci.plugins
       artifactId: node-iterator-api
-      version: '1.5'
+      version: '1.5.0'
     - groupId: org.jenkins-ci.plugins
       artifactId: pipeline-build-step
       version: '2.7'

--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -69,38 +69,33 @@ spec:
     - groupId: io.jenkins.plugins
       artifactId: artifact-manager-s3
       version: '1.1'
-      # transitive dependencies that we want to force the upgrade of
-      # Note: it would be nice to have a way to fail the evergreen build if
-      # those things below are *not* already pulled in transitively and just
-      # the version is bumped
     - groupId: org.jenkins-ci.plugins
       artifactId: authentication-tokens
       version: '1.3'
     - groupId: org.jenkins-ci.plugins
       artifactId: conditional-buildstep
-      version: '1.3.6'
+      version: 1.3.6
     - groupId: org.jenkins-ci.plugins.icon-shim
       artifactId: icon-shim
-      version: '2.0.3'
+      version: 2.0.3
     - groupId: org.jenkins-ci.plugins
       artifactId: javadoc
       version: '1.4'
     - groupId: org.jenkins-ci.plugins
       artifactId: jsch
-      version: '0.1.54.2'
+      version: 0.1.54.2
     - groupId: org.jenkins-ci.plugins
       artifactId: mapdb-api
-      version: '1.0.9.0'
+      version: 1.0.9.0
     - groupId: org.jenkins-ci.main
       artifactId: maven-plugin
-      version: '3.1.2'
+      version: 3.1.2
     - groupId: org.jenkins-ci.plugins
       artifactId: node-iterator-api
-      version: '1.5.0'
+      version: 1.5.0
     - groupId: org.jenkins-ci.plugins
       artifactId: run-condition
       version: '1.0'
-
   environments:
     - name: docker-cloud
       plugins:
@@ -222,6 +217,9 @@ status:
       artifactId: cloudbees-folder
       version: '6.3'
     - groupId: org.jenkins-ci.plugins
+      artifactId: conditional-buildstep
+      version: 1.3.6
+    - groupId: org.jenkins-ci.plugins
       artifactId: config-file-provider
       version: '2.18'
     - groupId: io.jenkins
@@ -283,10 +281,13 @@ status:
       version: '1.16'
     - groupId: org.jenkins-ci.plugins.icon-shim
       artifactId: icon-shim
-      version: '2.0.3'
+      version: 2.0.3
     - groupId: org.jenkins-ci.plugins
       artifactId: jackson2-api
       version: 2.8.11.2
+    - groupId: org.jenkins-ci.plugins
+      artifactId: javadoc
+      version: '1.4'
     - groupId: org.jenkins-ci.plugins
       artifactId: jdk-tool
       version: '1.1'
@@ -301,7 +302,7 @@ status:
       version: 1.2.1
     - groupId: org.jenkins-ci.plugins
       artifactId: jsch
-      version: 0.1.54.1
+      version: 0.1.54.2
     - groupId: org.jenkins-ci.plugins
       artifactId: junit
       version: '1.24'
@@ -309,11 +310,17 @@ status:
       artifactId: mailer
       version: '1.21'
     - groupId: org.jenkins-ci.plugins
+      artifactId: mapdb-api
+      version: 1.0.9.0
+    - groupId: org.jenkins-ci.plugins
       artifactId: matrix-auth
       version: '2.2'
     - groupId: org.jenkins-ci.plugins
       artifactId: matrix-project
       version: 1.7.1
+    - groupId: org.jenkins-ci.main
+      artifactId: maven-plugin
+      version: 3.1.2
     - groupId: org.jenkins-ci.plugins
       artifactId: mercurial
       version: '2.4'
@@ -325,7 +332,7 @@ status:
       version: '1.1'
     - groupId: org.jenkins-ci.plugins
       artifactId: node-iterator-api
-      version: '1.5.0'
+      version: '1.5'
     - groupId: org.jenkins-ci.plugins
       artifactId: pipeline-build-step
       version: '2.7'
@@ -368,6 +375,9 @@ status:
     - groupId: org.jenkins-ci.plugins
       artifactId: pubsub-light
       version: '1.12'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: run-condition
+      version: '1.0'
     - groupId: org.jenkins-ci.plugins
       artifactId: scm-api
       version: 2.2.7

--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -72,9 +72,6 @@ spec:
     - groupId: org.jenkins-ci.plugins
       artifactId: authentication-tokens
       version: '1.3'
-    - groupId: org.jenkins-ci.plugins
-      artifactId: conditional-buildstep
-      version: 1.3.6
     - groupId: org.jenkins-ci.plugins.icon-shim
       artifactId: icon-shim
       version: 2.0.3
@@ -84,9 +81,6 @@ spec:
     - groupId: org.jenkins-ci.plugins
       artifactId: jsch
       version: 0.1.54.2
-    - groupId: org.jenkins-ci.plugins
-      artifactId: mapdb-api
-      version: 1.0.9.0
     - groupId: org.jenkins-ci.main
       artifactId: maven-plugin
       version: 3.1.2
@@ -211,9 +205,6 @@ status:
       artifactId: cloudbees-folder
       version: '6.3'
     - groupId: org.jenkins-ci.plugins
-      artifactId: conditional-buildstep
-      version: 1.3.6
-    - groupId: org.jenkins-ci.plugins
       artifactId: config-file-provider
       version: '2.18'
     - groupId: io.jenkins
@@ -304,9 +295,6 @@ status:
       artifactId: mailer
       version: '1.21'
     - groupId: org.jenkins-ci.plugins
-      artifactId: mapdb-api
-      version: 1.0.9.0
-    - groupId: org.jenkins-ci.plugins
       artifactId: matrix-auth
       version: '2.2'
     - groupId: org.jenkins-ci.plugins
@@ -369,9 +357,6 @@ status:
     - groupId: org.jenkins-ci.plugins
       artifactId: pubsub-light
       version: '1.12'
-    - groupId: org.jenkins-ci.plugins
-      artifactId: run-condition
-      version: '1.0'
     - groupId: org.jenkins-ci.plugins
       artifactId: scm-api
       version: 2.2.7


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-53285 this should already reduce the number of warnings we receive in Sentry.

cc @jglick 