### PR TITLE
[JENKINS-53304] Mount volume on the whole /evergreen

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,12 +41,13 @@ restarted if necessary.
 .Starting Jenkins Evergreen
 [source,bash]
 ----
-mkdir $PWD/jenkins-home && \
+docker volume create jenkins-evergreen-data && \
 docker run --name evergreen \
+    --restart=always \
+    -ti \
     -p 8080:8080 \
-    -u 0 \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $PWD/jenkins-home:/evergreen/jenkins/home \
+    -v jenkins-evergreen-data:/evergreen/ \
     -e LOG_LEVEL=debug \
     jenkins/evergreen:docker-cloud
 ----
@@ -62,7 +63,7 @@ docker exec evergreen cat /evergreen/jenkins/home/secrets/initialAdminPassword
 ----
 
 
-=== Getting started with an AWS-baesd installation
+=== Getting started with an AWS-based installation
 
 [NOTE]
 ====
@@ -155,7 +156,7 @@ documents:
 | link:https://github.com/jenkinsci/jep/blob/master/jep/309[Bill of Materials]
 
 | JEP-310
-| link:https://github.com/jenkinsci/jep/blob/master/jep/310 [Evergreen AWS auto-configuration]
+| link:https://github.com/jenkinsci/jep/blob/master/jep/310[Evergreen AWS auto-configuration]
 
 |===
 


### PR DESCRIPTION
[JENKINS-53304](https://issues.jenkins-ci.org/browse/JENKINS-53304): Data loss when running on newly pulled version of the evergreen image

Without this, we lose data outside of _/evergreen/jenkins/home_ when running a new container, because we were mounting only this directory. We now mount the whole `/evergreen`.

Reported originally by @jglick in the chat. Only took time to confirm it yesterday.