### PR TITLE
[JENKINS-53285] bump to fixed version of node-iterator-api plugin

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -104,6 +104,9 @@ spec:
         - groupId: io.jenkins.plugins
           artifactId: artifact-manager-s3
           version: '1.1'
+        - groupId: org.jenkins-ci.plugins
+          artifactId: node-iterator-api
+          version: 1.5.0
 status:
   core:
     version: '2.138'


### PR DESCRIPTION
(This plugin is pulled in by the `ec2` plugin). 

[JENKINS-53285](https://issues.jenkins-ci.org/browse/JENKINS-53285)

Between `1.5` and `1.5.0`, the parent pom got updated. So we should not have this warning anymore using  `1.5.0`: https://github.com/jenkinsci/node-iterator-api-plugin/compare/7b284cb95b1ebcd09a430b94fd75d5599e867668...f73034788d1c8752ab7bef3af6aea664f3af674e

