### PR TITLE
Also pull the image before running

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,7 @@ restarted if necessary.
 [source,bash]
 ----
 docker volume create jenkins-evergreen-data && \
+docker pull jenkins/evergreen:docker-cloud && \
 docker run --name evergreen \
     --restart=always \
     -ti \


### PR DESCRIPTION
This will ensure running the latest image for cases where people have already tried/pulled evergreen previously.