### PR TITLE
Fix make run

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -30,6 +30,27 @@ The `Makefile` at the project root should help you getting started.
 want to start to understand how things work, and be able to modify them and see
 the impact.
 
+==== Running the whole stack locally
+
+To develop on a developer box and quite easily set up both the backend services and the Jenkins Evergreen instance, you need to do the following:
+
+[source,shell, title=from the repo root]
+make run
+# wait enough for services to be fully started. Should be <30 seconds.
+sleep 30
+cd distribution/
+curl --data-raw "{\"commit\":\"container-tests\",\"manifest\":$(cat ../services/ingest.json)}" \
+-H 'Authorization: the API calls are coming from inside the house' \
+-H 'Content-Type: application/json' \
+http://localhost:3030/update
+
+As soon as you post the `json` into that URL, you should see logs showing Evergreen has started to download plugins and so on.
+
+Then open your browser on http://localhost:8080 and you should see your development version for _Jenkins Evergreen_ coming up.
+
+TIP: Expect some delay for the first time, because you will need to many dozens of MB.
+However, an `squid` proxy cache is set up while using this `make run`, hence these downloads should be very fast the next times.
+
 === Code style
 
 We have defined a set of ESLint rules to keep the code style consistent.

--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -59,8 +59,12 @@ publish: container
 create-squid-cache-volume:
 	docker volume create ${SQUID_VOLUME_NAME}
 
-run: create-squid-cache-volume
-	$(COMPOSE) -f docker-compose.yml -f docker-compose.squid-cache.yml up
+run: create-squid-cache-volume container-check-prereqs
+	$(COMPOSE) -f docker-compose.yml \
+             -f docker-compose.squid-cache.yml \
+             -f tests/environments/docker-cloud/docker-compose.docker-cloud.yml \
+             up
+
 
 clean:
 	$(COMPOSE) down || true

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     environment:
       - 'EVERGREEN_ENDPOINT=http://backend:3030'
       - 'LOG_LEVEL=info'
-      - 'INSECURE_SHOW_ADMIN_PASSWORD=yes'
+      - 'INSECURE_SHOW_ADMIN_PASSWORD=true'
     ports:
       - '8080:8080'
     depends_on:

--- a/distribution/scripts/jenkins-evergreen.sh
+++ b/distribution/scripts/jenkins-evergreen.sh
@@ -24,7 +24,7 @@ fi
 JENKINS_ADMIN_PASSWORD="$( cat "$passwordFileLocation" )"
 
 # Intended for ease of development. By default, password is obviously *not* put in logs.
-if [[ "${INSECURE_SHOW_ADMIN_PASSWORD:-yes}" == "true" ]]; then
+if [[ "${INSECURE_SHOW_ADMIN_PASSWORD:-false}" == "true" ]]; then
   echo "[WARNING] INSECURE_SHOW_ADMIN_PASSWORD defined, it should only ever be done for testing."
   echo "[admin password] $JENKINS_ADMIN_PASSWORD"
 fi

--- a/distribution/tests/utilities
+++ b/distribution/tests/utilities
@@ -27,7 +27,7 @@ cleanup () {
 
   echo -n "Retrieving test run data (container logs, ...) before shutdown... Will be in the $testRunDirectory directory... "
   # Normally should be something like evergreen_backend_1, evergreen_db_1 and evergreen_instance_1
-  containers=$( $COMPOSE ps | head -5 | tail -3 | awk '{print $1}' )
+  containers=$( $COMPOSE ps | head -5 | tail -4 | awk '{print $1}' )
 
   for container in $containers
   do


### PR DESCRIPTION
Mainly, `make run` was failing because the `FLAVOR` is undefined.
So we now use the `docker-cloud` flavor for local testing.

I went on fixing that while starting to work on [JENKINS-53215](https://issues.jenkins-ci.org/browse/JENKINS-53215).