### PR TITLE
[JENKINS-53318] Force docker-commons:1.9 and token-macro:2.3

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -72,6 +72,12 @@ spec:
     - groupId: org.jenkins-ci.plugins
       artifactId: jsch
       version: 0.1.54.2
+    - groupId: org.jenkins-ci.plugins
+      artifactId: docker-commons
+      version: '1.9'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: token-macro
+      version: '2.3'
   environments:
     - name: docker-cloud
       plugins:
@@ -200,7 +206,7 @@ status:
       version: 2.2.0
     - groupId: org.jenkins-ci.plugins
       artifactId: docker-commons
-      version: '1.5'
+      version: '1.9'
     - groupId: org.jenkins-ci.plugins
       artifactId: docker-workflow
       version: '1.14'
@@ -344,7 +350,7 @@ status:
       version: '1.14'
     - groupId: org.jenkins-ci.plugins
       artifactId: token-macro
-      version: '2.0'
+      version: '2.3'
     - groupId: org.jenkins-ci.plugins
       artifactId: variant
       version: '1.1'
@@ -385,9 +391,6 @@ status:
     - name: docker-cloud
       plugins:
         - groupId: org.jenkins-ci.plugins
-          artifactId: docker-commons
-          version: '1.9'
-        - groupId: org.jenkins-ci.plugins
           artifactId: docker-java-api
           version: 3.0.14
         - groupId: io.jenkins.docker
@@ -396,9 +399,6 @@ status:
         - groupId: org.jenkins-ci.plugins
           artifactId: ssh-slaves
           version: '1.22'
-        - groupId: org.jenkins-ci.plugins
-          artifactId: token-macro
-          version: '2.3'
     - name: aws-ec2-cloud
       plugins:
         - groupId: io.jenkins.plugins


### PR DESCRIPTION
Temporary workaround for [JENKINS-53318](https://issues.jenkins-ci.org/browse/JENKINS-53318) to avoid crashing Jenkins during startup with

```
[SEVERE][2018-08-31 05:54:19] Failed Loading plugin Docker plugin v1.1.5 (docker-plugin) (from jenkins.InitReactorRunner$1 onTaskFailed)
java.io.IOException: Docker plugin v1.1.5 failed to load.
 - Docker Commons Plugin v1.5 is older than required. To fix, install v1.9 or later.
 - Token Macro Plugin v2.0 is older than required. To fix, install v2.3 or later.
        at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:652)
        at hudson.PluginManager$2$1$1.run(PluginManager.java:517)
        at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1066)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```