### PR TITLE
[JENKINS-53215] Configure Secure defaults OOTB

### DIFF
--- a/distribution/config/as-code/create-admin-user.yaml
+++ b/distribution/config/as-code/create-admin-user.yaml
@@ -1,6 +1,7 @@
 jenkins:
+  # Agent to master security
   remotingSecurity:
-    enabled: false
+    enabled: true
   securityRealm:
     local:
       allowsSignup: false
@@ -8,3 +9,10 @@ jenkins:
         - id: "admin"
           password: ${JENKINS_ADMIN_PASSWORD}
   authorizationStrategy: loggedInUsersCanDoAnything
+  #CSRF issuer
+  crumbIssuer:
+    standard:
+      excludeClientIPFromCrumb: false
+security:
+  remotingCLI:
+    enabled: false


### PR DESCRIPTION
[JENKINS-53215](https://issues.jenkins-ci.org/browse/JENKINS-53215)

Jenkins Evergreen should have no Admin monitor related to secure defaults showing under /manage after startup.

----
Note: for now, this does not fix the `Jenkins root URL is empty but is required for the proper operation of many Jenkins features like email notifications, PR status update, and environment variables such as BUILD_URL.` monitor:

![image](https://user-images.githubusercontent.com/223853/44911324-c6c59480-ad26-11e8-9bfb-f7f730bcde4f.png)

This one has been fixed only very recently in the core itself, and requires us to guide users to the /configure page and save it, since we cannot know in advance what the value is going to be, at least for the Docker Cloud flavor.
We might be able to do it though for the AWS flavor.
That is not a security related issue however, so it's not very critical at this point.