### PR TITLE
Revert "[JENKINS-53318] Force docker-commons:1.9 and token-macro:2.3"

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -72,12 +72,6 @@ spec:
     - groupId: org.jenkins-ci.plugins
       artifactId: jsch
       version: 0.1.54.2
-    - groupId: org.jenkins-ci.plugins
-      artifactId: docker-commons
-      version: '1.9'
-    - groupId: org.jenkins-ci.plugins
-      artifactId: token-macro
-      version: '2.3'
   environments:
     - name: docker-cloud
       plugins:
@@ -206,7 +200,7 @@ status:
       version: 2.2.0
     - groupId: org.jenkins-ci.plugins
       artifactId: docker-commons
-      version: '1.9'
+      version: '1.5'
     - groupId: org.jenkins-ci.plugins
       artifactId: docker-workflow
       version: '1.14'
@@ -350,7 +344,7 @@ status:
       version: '1.14'
     - groupId: org.jenkins-ci.plugins
       artifactId: token-macro
-      version: '2.3'
+      version: '2.0'
     - groupId: org.jenkins-ci.plugins
       artifactId: variant
       version: '1.1'
@@ -391,6 +385,9 @@ status:
     - name: docker-cloud
       plugins:
         - groupId: org.jenkins-ci.plugins
+          artifactId: docker-commons
+          version: '1.9'
+        - groupId: org.jenkins-ci.plugins
           artifactId: docker-java-api
           version: 3.0.14
         - groupId: io.jenkins.docker
@@ -399,6 +396,9 @@ status:
         - groupId: org.jenkins-ci.plugins
           artifactId: ssh-slaves
           version: '1.22'
+        - groupId: org.jenkins-ci.plugins
+          artifactId: token-macro
+          version: '2.3'
     - name: aws-ec2-cloud
       plugins:
         - groupId: io.jenkins.plugins


### PR DESCRIPTION
This reverts commit 44a1ba17579ab22489387c8362d59a5842f73e21, i.e. reverts https://github.com/jenkins-infra/evergreen/pull/218

Production version for https://evergreen.jenkins.io is now supposed to be the one from Friday (`201808300831`), cf. https://github.com/jenkins-infra/jenkins-infra/pull/1096/files#diff-0929d2e1dc2d61889d42d3c9bca6843fR351

AIUI, https://github.com/jenkins-infra/evergreen/commit/21733e1228f9341b755d4727cc3ab08e52221352 actually fixes/fixed [JENKINS-53318](https://issues.jenkins-ci.org/browse/JENKINS-53318), but was just not deployed yet. That would explain why instances were bricked when running publicly, but we couldn't see any failure in our Pipeline.

---

IOW, the goal here is to:
* go back to the problematic situation before
* make sure the right version for plugins is now selected when creating a new evergreen instance, hence does not brick instances OOTB...