### PR TITLE
[JENKINS-53357] Error logs will fill up production disk indefinitely

### DIFF
--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -162,10 +162,7 @@ test_metrics_health_check() {
 # JENKINS-49811
 test_logs_are_propagated() {
 
-  # shellcheck disable=SC2016
-  error_logging_filename=$( $COMPOSE exec -T backend sh -c 'echo $ERROR_LOGGING_FILE' )
-  assertEquals "ERROR_LOGGING_FILE env variable should be defined" "0" "$?"
-  assertNotEquals "Env var value should not not be empty" "" "$error_logging_filename"
+  error_logging_filename='/tmp/error-telemetry-testing.log';
 
   result=$( $COMPOSE exec -T backend cat "$error_logging_filename" )
 

--- a/services/Dockerfile
+++ b/services/Dockerfile
@@ -26,5 +26,4 @@ EXPOSE 3030
 
 COPY wait-for-postgres.sh /wait-for-postgres.sh
 RUN apk add --update-cache postgresql-client && chmod a+x /wait-for-postgres.sh
-ENV ERROR_LOGGING_FILE ${APP_DIR}/error-logging.json
 CMD npm run start

--- a/services/test/services/errortelemetry.test.js
+++ b/services/test/services/errortelemetry.test.js
@@ -58,7 +58,7 @@ describe('Error Telemetry', () => {
     assert.ok(response, 'A log should have been stored');
     assert.equal(response.status, 'OK', 'The log should have been stored');
 
-    const fileContent = fs.readFileSync(process.env.ERROR_LOGGING_FILE);
+    const fileContent = fs.readFileSync('/tmp/error-telemetry-testing.log');
     assert.notEqual(fileContent, '', 'Log file should not be empty');
 
   });

--- a/tools/node
+++ b/tools/node
@@ -26,7 +26,6 @@ exec docker run --net host --rm ${TTY_ARGS} \
     -e DB_TRACING=$DB_TRACING \
     -e LOG_LEVEL=$LOG_LEVEL \
     -e FLAVOR=$FLAVOR \
-    -e ERROR_LOGGING_FILE=/tmp/evergreen-errosr.json \
     $(printenv | grep -i \^evergreen | awk '{ print "-e", $1 }') \
     $(printenv | grep -i \^node | awk '{ print "-e", $1 }') \
     node:9-alpine \


### PR DESCRIPTION
[JENKINS-53357](https://issues.jenkins-ci.org/browse/JENKINS-53357)

No need for a `ERROR_LOGGING_FILE` env var anymore.

We now use the (mostly) standard `NODE_ENV` variable to disable that file logging in production.
It is still enabled in non-production because it allows to test that the error telemetry messages flow correctly from client to the backend.