### PR TITLE
Better indicate which log was sent to the error telemetry backend

### DIFF
--- a/distribution/client/src/lib/error-telemetry.js
+++ b/distribution/client/src/lib/error-telemetry.js
@@ -39,7 +39,7 @@ class ErrorTelemetry {
         headers: { Authorization: this.token }
       }
     )
-      .then(res => logger.debug('Pushed error as', res))
+      .then(res => logger.debug(`Pushed error log (message='${logDataObject.message}'). Backend response:`, res))
       .catch(err => logger.error('Failed to push log', err));
   }
 

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     build: ./
     environment:
       - 'EVERGREEN_ENDPOINT=http://backend:3030'
-      - 'LOG_LEVEL=info'
+      - 'LOG_LEVEL=debug'
       - 'INSECURE_SHOW_ADMIN_PASSWORD=true'
     ports:
       - '8080:8080'


### PR DESCRIPTION
Currently, messages all look like

```
debug: Pushed error as status=OK
```

This is not very informative, and in case there seems to have issues or
some messages that weren't received, it's hard to debug what the client
"thinks" it did send correctly.

So, now we log the message field to allow match the error telemetry
service with the log just displayed by Jenkins. Example:

```
debug: Pushed error log (message='Evergreen plugin: \nPlugin has started! Please ignore the following exception'). Backend response: status=OK
```