### PR TITLE
Increase the timeout for some of our more flakey tests and restructure

### DIFF
--- a/distribution/client/test/downloader.test.js
+++ b/distribution/client/test/downloader.test.js
@@ -34,7 +34,7 @@ describe('the Downloader class', () => {
       // FIXME: introduce assume() + env var to allow disabling this?
       beforeEach(() => {
         // default is 5 seconds, could be bigger because of the file size
-        jest.setTimeout(50000);
+        jest.setTimeout(120000);
       });
 
       it('should fail on an invalid signature', async () => {
@@ -43,10 +43,10 @@ describe('the Downloader class', () => {
             dir,
             'index.html',
             'bogus-signature');
+          expect(true).toBeFalsy();
         } catch (err) {
           expect(err.message.startsWith('Signature verification')).toBeTruthy();
         }
-        expect.assertions(1);
       });
 
       it('should manage to download a decently big file, retrying if needed', async () => {


### PR DESCRIPTION
It's still unclear why these are failing in trusted.ci, and _only_ in
trusted.co.

See:
    https://gist.github.com/rtyler/fa8dad5b4e23ac49fdf5ab6170439c75