### PR TITLE
[JENKINS-53273] JEP-302: initialize Git repo and snapshot state on upgrade

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -58,7 +58,8 @@ RUN apk add --no-cache git \
                         curl \
                         socat \
                         wget \
-                        nginx
+                        nginx \
+                        git # JEP-302
 
 # Ensure the latest npm is available
 RUN npm install npm@latest -g

--- a/distribution/client/src/lib/snapshotter.js
+++ b/distribution/client/src/lib/snapshotter.js
@@ -79,7 +79,7 @@ class Snapshotter {
       logger.info(`${LOG_PREFIX} .gitignore outdated or absent, updating.`);
       fs.writeFileSync(gitignorePath, GITIGNORE_CONTENT);
       this.git('add', '.gitignore');
-      this.git('commit', '--message', 'Update.gitignore content to latest');
+      this.git('commit', '--message', 'Update .gitignore content to latest');
     } else {
       logger.info(`${LOG_PREFIX} .gitignore up to date already.`);
     }

--- a/distribution/client/src/lib/snapshotter.js
+++ b/distribution/client/src/lib/snapshotter.js
@@ -1,0 +1,127 @@
+/*
+* Used for snapshotting and rollbacks during upgrades.
+* See:
+*  https://github.com/jenkinsci/jep/tree/master/jep/302
+*/
+
+const { spawnSync } = require('child_process');
+const logger        = require('winston');
+const fs            = require('fs');
+
+const LOG_PREFIX = '[snapshotting]';
+// https://github.com/jenkinsci/jep/tree/master/jep/302#user-content-files-to-store
+const GITIGNORE_CONTENT = `
+/plugins/
+/updates/
+/secrets/master.key
+`;
+
+class Snapshotter {
+
+  constructor(app, options) {
+    this.options = options || {};
+  }
+
+  init(workingDirectory) {
+    if (!workingDirectory) {
+      throw new Error('workingDirectory parameter is required');
+    }
+    this.workingDirectory = workingDirectory;
+
+    if (!fs.existsSync(this.getDotGitDirectory())) {
+      this.git('init');
+      this.git('config', 'user.email', 'evergreen-client@jenkins.io');
+      this.git('config', 'user.name', '"Evergreen Client Snapshotting System (JEP 302)"');
+      this.git('commit','--allow-empty', '--message', 'Initial evergreen commit');
+
+      fs.writeFile(`${this.getDotGitDirectory()}/description`,
+        `This repository is used and specifically designed for Evergreen snapshotting system
+    (https://github.com/jenkinsci/jep/tree/master/jep/302).
+    It is *not* intended to act as a backup system in any way.
+    Never push this repository outside of the Evergreen container to avoid any risk of
+    leaking sensitive data.`,
+        (err) => {
+          if (err) {
+            logger.error('Impossible to write the repository description. Abnormal but not blocking.', err);
+          }
+        });
+    } else {
+      logger.info(`${LOG_PREFIX} ${this.getDotGitDirectory()} already initialized, moving on`);
+    }
+    this.updateGitIgnore();
+  }
+
+  /**
+   * https://github.com/jenkinsci/jep/tree/master/jep/302#take-a-snapshot
+   */
+  // TODO: design what needs to be passed (UL from/to, etc.)
+  snapshot(message) {
+    if (!this.workingDirectory) {
+      throw new Error('init() must be called first');
+    }
+
+    this.updateGitIgnore();
+
+    this.git('add', '--all');
+    // TODO: allow-empty but should trigger a warning if nothing was changed
+    this.git('commit', '--allow-empty', '--message', `${message}`);
+  }
+
+  /**
+   * Will update the .gitignore file and commit if needed.
+   * No-Op if already containing the expected content.
+   */
+  updateGitIgnore() {
+    const gitignorePath = `${this.workingDirectory}/.gitignore`;
+
+    if (!fs.existsSync(gitignorePath) ||
+        fs.readFileSync(gitignorePath, 'utf-8') !== GITIGNORE_CONTENT ) {
+      logger.info(`${LOG_PREFIX} .gitignore outdated or absent, updating.`);
+      fs.writeFileSync(gitignorePath, GITIGNORE_CONTENT);
+      this.git('add', '.gitignore');
+      this.git('commit', '--message', 'Update.gitignore content to latest');
+    } else {
+      logger.info(`${LOG_PREFIX} .gitignore up to date already.`);
+    }
+  }
+
+  getDotGitDirectory() {
+    return `${this.workingDirectory}/.git`;
+  }
+
+  /**
+   * Calls git with the passed arguments.
+   * Synchronous function, hence will return once the command completes.
+   Will throw an Error if the command failed or timed out.
+   */
+  git(...args) {
+    const options = {
+      cwd: this.workingDirectory,
+      encoding: 'utf-8',
+      timeout: 30 * 1000 // could this become too small for big setups?
+    };
+
+    const cmd = `git ${args.join(' ')}`;
+    logger.info(`${LOG_PREFIX} Running '${cmd}' command in ${this.workingDirectory}`);
+
+    const result = spawnSync('git', args, options);
+    if (result.stdout && result.stdout.length > 0) {
+      logger.info(`${LOG_PREFIX} stdout: '${result.stdout.toString()}'`);
+    }
+    if (result.stderr && result.stderr.length > 0) {
+      logger.error(`${LOG_PREFIX} stderr: '${result.stderr.toString()}'`);
+    }
+    if (result.status && result.status !== 0) {
+      const errorMessage = `${LOG_PREFIX} Error exit code '${result.status}' while executing command '${cmd}'`;
+      logger.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    if (result.error) {
+      const errorMessage = `${LOG_PREFIX} Error while executing command '${cmd}': ${result.error}`;
+      logger.error(errorMessage);
+      throw result.error;
+    }
+  }
+}
+
+module.exports = Snapshotter;

--- a/distribution/client/src/lib/snapshotter.js
+++ b/distribution/client/src/lib/snapshotter.js
@@ -46,7 +46,7 @@ class Snapshotter {
           }
         });
     } else {
-      logger.info(`${LOG_PREFIX} ${this.getDotGitDirectory()} already initialized, moving on`);
+      logger.debug(`${LOG_PREFIX} ${this.getDotGitDirectory()} already initialized, moving on`);
     }
     this.updateGitIgnore();
   }

--- a/distribution/client/src/lib/update.js
+++ b/distribution/client/src/lib/update.js
@@ -94,7 +94,7 @@ class Update {
     });
 
     return Promise.all(tasks).then(() => {
-      this.snapshotter.snapshot(`UL{this.getCurrentLevel()}->UL${updates.meta.level} Snapshot after downloads completed, before Jenkins restart`);
+      this.snapshotter.snapshot(`UL${this.getCurrentLevel()}->UL${updates.meta.level} Snapshot after downloads completed, before Jenkins restart`);
       UI.publish('All downloads completed, restarting Jenkins');
       this.saveUpdateSync(updates);
       Supervisord.restartProcess('jenkins');

--- a/distribution/client/src/lib/update.js
+++ b/distribution/client/src/lib/update.js
@@ -94,8 +94,9 @@ class Update {
     });
 
     return Promise.all(tasks).then(() => {
+      UI.publish('All downloads completed, snapshotting data before restart');
       this.snapshotter.snapshot(`UL${this.getCurrentLevel()}->UL${updates.meta.level} Snapshot after downloads completed, before Jenkins restart`);
-      UI.publish('All downloads completed, restarting Jenkins');
+      UI.publish('All downloads completed and snapshotting done, restarting Jenkins');
       this.saveUpdateSync(updates);
       Supervisord.restartProcess('jenkins');
       // TODO: This should really only be set once the instance is back online

--- a/distribution/client/test/client.test.js
+++ b/distribution/client/test/client.test.js
@@ -1,12 +1,22 @@
 const assert = require('assert');
+const tmp      = require('tmp');
 const Client = require('../src/client');
+const Storage  = require('../src/lib/storage');
+const mkdirp   = require('mkdirp');
 
 describe('The base client module', () => {
+
   it('should interpret properly', () => {
     assert(Client);
   });
 
   describe('flavorCheck', () => {
+    beforeEach( () => {
+      const evergreenHome = tmp.dirSync({unsafeCleanup: true}).name;
+      Storage.homeDirectory = (() => evergreenHome );
+      mkdirp.sync(Storage.jenkinsHome());
+    });
+
     it('should throw an error with no flavor defined', () => {
       expect(() => {
         delete process.env.FLAVOR;
@@ -16,8 +26,16 @@ describe('The base client module', () => {
   });
 
   describe('isOffline()', () => {
-    process.env.FLAVOR = 'docker-cloud';
-    let client = new Client();
+    let client = null;
+
+    beforeEach( () => {
+      const evergreenHome = tmp.dirSync({unsafeCleanup: true}).name;
+      Storage.homeDirectory = (() => evergreenHome );
+      mkdirp.sync(Storage.jenkinsHome());
+      process.env.FLAVOR = 'docker-cloud';
+      client = new Client();
+    });
+
 
     it('should default to false', () => {
       expect(client.isOffline()).toBeFalsy();

--- a/distribution/client/test/snapshotter.test.js
+++ b/distribution/client/test/snapshotter.test.js
@@ -1,0 +1,48 @@
+const Snapshotter = require('../src/lib/snapshotter');
+const tmp         = require('tmp');
+const fs          = require('fs');
+
+describe('The snapshotting module', () => {
+
+  let tmpDir = '';
+  beforeEach(() => {
+    tmpDir = tmp.dirSync({unsafeCleanup: true});
+  });
+
+  afterEach(() => {
+    tmpDir.removeCallback();
+  });
+
+  describe('init()', () => {
+    it('should init a repo', () => {
+      const snapshotter = new Snapshotter();
+      snapshotter.init(tmpDir.name);
+
+      // Called twice does not crash:
+      // important since this is what will happen
+      // on container/client restart
+      snapshotter.init(tmpDir.name);
+    });
+  });
+  describe('snapshot()', () => {
+    it('should create a commit()', () => {
+      const snapshotter = new Snapshotter();
+      snapshotter.init(tmpDir.name);
+      fs.writeFileSync(`${tmpDir.name}/blah.file`, 'something');
+      snapshotter.snapshot('yay test message');
+
+      const gitIgnore = fs.readFileSync(`${tmpDir.name}/.gitignore`,'utf-8');
+      expect(gitIgnore).toContain('/plugins/');
+      expect(gitIgnore).toContain('secrets/master.key');
+    });
+    it('should create a commit even without file()', () => {
+      const snapshotter = new Snapshotter();
+      snapshotter.init(tmpDir.name);
+
+      snapshotter.snapshot('yay test message');
+    });
+
+    // TODO: test ./plugins is "gitignored"
+  });
+
+});

--- a/distribution/client/test/update.test.js
+++ b/distribution/client/test/update.test.js
@@ -1,18 +1,24 @@
-jest.mock('fs');
-
 const assert   = require('assert');
+const tmp      = require('tmp');
 const fs       = require('fs');
 const feathers = require('@feathersjs/feathers');
 const Update   = require('../src/lib/update');
+const Storage  = require('../src/lib/storage');
+const mkdirp   = require('mkdirp');
 
 
 describe('The update module', () => {
-  let app = feathers();
-  let update = new Update(app);
 
-  beforeEach(() => {
-    /* Make sure memfs is flushed every time */
-    fs.volume.reset();
+  let app = null;
+  let update = null;
+  beforeEach( () => {
+    const evergreenHome = tmp.dirSync({unsafeCleanup: true}).name;
+    Storage.homeDirectory = (() => evergreenHome );
+    mkdirp.sync(Storage.jenkinsHome());
+
+    app = feathers();
+    update = new Update(app);
+
   });
 
   describe('authenticate()', () => {

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -251,10 +251,12 @@ test_secure_defaults_ootb() {
 test_git_history_is_present() {
   commitCount=$( docker exec -w "$JENKINS_HOME" "$container_under_test" git rev-list --count HEAD )
   assertEquals "git call to count commits should have succeeded" 0 "$?"
-  assertEquals "commit count should be 4" 4 "$commitCount"
+  # Depending on if ingest.json is pushed to backend before or after the client first
+  # polls the backend, we'll get 3 or 4 commits...
+  assertTrue "[ $commitCount -ge 3 ]"
 
   docker exec -w "$JENKINS_HOME" "$container_under_test" git log --pretty=format:%s HEAD~..HEAD | \
-                grep 'UL1->UL2' > /dev/null
+                grep 'Snapshot after downloads completed, before Jenkins restart' > /dev/null
   assertEquals "git call to retrieve last subject should have succeeded" 0 "$?"
 }
 

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -253,6 +253,7 @@ test_git_history_is_present() {
   assertEquals "git call to count commits should have succeeded" 0 "$?"
   # Depending on if ingest.json is pushed to backend before or after the client first
   # polls the backend, we'll get 3 or 4 commits...
+  # See JENKINS-53499
   assertTrue "[ $commitCount -ge 3 ]"
 
   docker exec -w "$JENKINS_HOME" "$container_under_test" git log --pretty=format:%s HEAD~..HEAD | \

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -247,4 +247,15 @@ test_secure_defaults_ootb() {
   assertNotEquals "Agent to master security should be enabled" 0 "$?"
 }
 
+# JENKINS-53273
+test_git_history_is_present() {
+  commitCount=$( docker exec -w "$JENKINS_HOME" "$container_under_test" git rev-list --count HEAD )
+  assertEquals "git call to count commits should have succeeded" 0 "$?"
+  assertEquals "commit count should be 4" 4 "$commitCount"
+
+  docker exec -w "$JENKINS_HOME" "$container_under_test" git log --pretty=format:%s HEAD~..HEAD | \
+                grep 'UL1->UL2' > /dev/null
+  assertEquals "git call to retrieve last subject should have succeeded" 0 "$?"
+}
+
 . ./shunit2/shunit2

--- a/tools/node
+++ b/tools/node
@@ -28,5 +28,5 @@ exec docker run --net host --rm ${TTY_ARGS} \
     -e FLAVOR=$FLAVOR \
     $(printenv | grep -i \^evergreen | awk '{ print "-e", $1 }') \
     $(printenv | grep -i \^node | awk '{ print "-e", $1 }') \
-    node:9-alpine \
+    node:10 \
     ${COMMAND}


### PR DESCRIPTION
Part of [JENKINS-53273](https://issues.jenkins-ci.org/browse/JENKINS-53273) 

**Ready for separate review, and merge if approved.**

The overall story is still WIP, but this PR adds the foundation for the snapshotting:
* the Git/Snapshotter API itself
* integrated with this updates to create commits before upgrades.

I think we could have this merged already separately if the approach looks reasonable. I think it is interesting to deliver this progressively so that we can possibly notice issues already around creating that repository on the disk.

In the meantime, I'm already working on providing the full story based on this: as per JEP-302, leverage this data to be able to roll back if the Health checking tells us we should stop and go back to where we were.