### PR TITLE
Avoid passing invalid core information into an Update test, causing a…

### DIFF
--- a/distribution/client/test/update.test.js
+++ b/distribution/client/test/update.test.js
@@ -62,6 +62,7 @@ describe('The update module', () => {
     beforeEach(() => {
       update.updateInProgress = false;
     });
+
     it('should not run if the instance is already updating', () => {
       update.updateInProgress = true;
       expect(update.applyUpdates()).resolves.toBeFalsy();
@@ -74,12 +75,6 @@ describe('The update module', () => {
 
     it('should not reject on no plugin updates', async () => {
       let manifest = {
-        core: {
-          url: 'https://jenkins.io/index.html',
-          checksum: {
-            signature: '0xdeadbeef',
-          }
-        },
         plugins: {},
       };
       let response = await update.applyUpdates(manifest);


### PR DESCRIPTION
…n invalid download to occur

Basically this test was inadvertently causing a download of jenkins.io and of
course, an invalid signature validation error to be raised

The async nature of the process resulted in a peculiar place for the error to
crop up however.

This could be reproduced by running `jest -i`

  ● the Downloader class › download() › should return promise

    Signature verification failed for /evergreen/jenkins/home/jenkins.war

      86 |                 UI.publish('Jenkins may fail to start properly! Please check your network connection');
      87 |                 UI.publish(`Signature verification failed for ${filename}! (${downloaded} != ${sha256})`, { log: 'error' });
    > 88 |                 return reject(new Error(`Signature verification failed for ${filename}`));
      89 |               }
      90 |             }
      91 |             return resolve(output);

      at class_2.output.on (src/lib/downloader.js:88:31)
      at node_modules/memfs/lib/volume.js:1892:15
      at Immediate.<anonymous> (node_modules/memfs/lib/volume.js:625:17)