### PR TITLE
Reduce log level + one-line-ify UI.publish log

### DIFF
--- a/distribution/client/src/lib/downloader.js
+++ b/distribution/client/src/lib/downloader.js
@@ -70,7 +70,7 @@ class Downloader {
       rp(options)
         .then((response) => {
           const elapsedString = Downloader.formatDuration(Date.now() - startTime);
-          logger.info  ('Download complete for', filename, `(Took ${elapsedString})`);
+          logger.info ('Download complete for', filename, `(Took ${elapsedString})`);
           UI.publish(`Fetched ${filename} in ${elapsedString}s`);
 
           const output = fs.createWriteStream(filename);
@@ -78,7 +78,7 @@ class Downloader {
           output.on('close', () => {
             logger.debug('Downloaded %s (%d bytes)', filename, output.bytesWritten);
             if (sha256) {
-              logger.error('Verifying signature for', filename);
+              logger.debug('Verifying signature for', filename);
               const downloaded = Checksum.signatureFromFile(filename);
 
               if (sha256 != downloaded) {
@@ -86,6 +86,8 @@ class Downloader {
                 UI.publish('Jenkins may fail to start properly! Please check your network connection');
                 UI.publish(`Signature verification failed for ${filename}! (${downloaded} != ${sha256})`, { log: 'error' });
                 return reject(new Error(`Signature verification failed for ${filename}`));
+              } else {
+                logger.debug(`Correct checksum (${sha256}) for`, filename);
               }
             }
             return resolve(output);

--- a/distribution/client/src/lib/ui.js
+++ b/distribution/client/src/lib/ui.js
@@ -27,7 +27,7 @@ class MessageService {
     if (params.log) {
       logger[params.log](data, params.error);
     } else {
-      logger.debug('Publishing to the UI:', data, params);
+      logger.debug(`Publishing to the UI: message='${JSON.stringify(data)}, params='${JSON.stringify(params)}'`);
     }
     this.recent.push(data);
     // Only keep the last 100 items


### PR DESCRIPTION
Change:

```
info: Download complete for /evergreen/jenkins/home/plugins/blueocean.hpi (Took 3.733s)
debug: Publishing to the UI: { message:
   'Fetched /evergreen/jenkins/home/plugins/blueocean.hpi in 3.733ss',
  timestamp: 1536571673041 }
debug: Downloaded /evergreen/jenkins/home/plugins/blueocean.hpi (7726 bytes)
error: Verifying signature for /evergreen/jenkins/home/plugins/blueocean.hpi
```

into

```
info: Download complete for /evergreen/jenkins/home/plugins/docker-plugin.hpi (Took 32.353s)
debug: Publishing to the UI: message='{"message":"Fetched /evergreen/jenkins/home/plugins/docker-plugin.hpi in 32.353ss","timestamp":1536574275389}, params='{}'
debug: Downloaded /evergreen/jenkins/home/plugins/docker-plugin.hpi (1057478 bytes)
debug: Verifying signature for /evergreen/jenkins/home/plugins/docker-plugin.hpi
debug: Correct checksum (46fa90e2c165bcc4b2885531e0863a45b97e67d647ca2b4fff09fe6046456a5d) for /evergreen/jenkins/home/plugins/docker-plugin.hpi
```