### PR TITLE
Stop exposing all ports, and do as the docs say currently

### DIFF
--- a/distribution/config/nginx.conf
+++ b/distribution/config/nginx.conf
@@ -111,6 +111,16 @@ http {
             proxy_pass http://jenkins;
         }
 
+        # Compatibility shim to allow Jenkins to have an /evergreen as well as
+        # the root nginx. This should only really be useful for testing, or
+        # in case nginx is acting really bezerk.
+        location /jenkins {
+            proxy_set_header Host $host:$server_port;
+            proxy_redirect http://localhost/ http://localhost:8080/;
+            rewrite /jenkins/(.*) /$1  break;
+            proxy_pass http://jenkins;
+        }
+
         location /evergreen {
             rewrite /evergreen/(.*) /$1  break;
             proxy_pass http://evergreen;

--- a/distribution/config/nginx.conf
+++ b/distribution/config/nginx.conf
@@ -98,29 +98,6 @@ http {
             rewrite /evergreen/static/(.*) /$1  break;
         }
 
-        # Default all requests to the home page to Blue Ocean, ahoy!
-        location = / {
-            return 301 /blue/pipelines;
-        }
-
-        # Only allow the usage of the Blue Ocean Pipeline creation flow.
-        # https://github.com/CodeValet/codevalet/issues/10
-        location = /newJob {
-            return 301 /blue/organizations/jenkins/create-pipeline;
-        }
-
-        # Disable plugin management for users who are not determined to
-        # destabilize their environment :)
-        location ^~ /pluginManager {
-            return 301 /evergreen/docs/#managing-plugins;
-        }
-
-        # Disable built-in tool management which is kind of a mess for any new
-        # user. Users should instead rely on Docker containers
-        location ^~ /configureTools {
-            return 301 /evergreen/docs/#managing-tools;
-        }
-
         location / {
             if ( -f /evergreen/booting.txt ) {
                 # Used by Cloudflare as "Web Server is down"

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -33,9 +33,7 @@ services:
       - 'LOG_LEVEL=debug'
       - 'INSECURE_SHOW_ADMIN_PASSWORD=true'
     ports:
-      - '8080:8080'
-      - '8081:8081'
-      - '80:80'
+      - '8080:80'
     depends_on:
       - backend
     volumes:

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -247,15 +247,4 @@ test_secure_defaults_ootb() {
   assertNotEquals "Agent to master security should be enabled" 0 "$?"
 }
 
-test_manage_plugins_restricted() {
-  # shellcheck disable=SC2016
-  adminPassword=$( docker exec "$container_under_test" bash -c 'cat $JENKINS_HOME/secrets/initialAdminPassword' )
-  result=$( curl -v -u "admin:$adminPassword" http://localhost/pluginManager/ 2>&1 )
-  assertEquals "curl call to /pluginManager should have succeeeded" 0 "$?"
-
-  echo "${result}" | grep "< Location: http://localhost/evergreen/docs/#managing-plugins"
-  assertEquals "/pluginManager did not properly redirect! ${result}" 0 "$?"
-}
-
-
 . ./shunit2/shunit2

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -210,7 +210,7 @@ test_no_maven_or_freestyle_jobs() {
   # shellcheck disable=SC2016
   adminPassword=$( docker exec "$container_under_test" bash -c 'cat $JENKINS_HOME/secrets/initialAdminPassword' )
 
-  topLevelDescriptor=$( curl --silent -u "admin:$adminPassword" http://localhost:$TEST_PORT/evergreen/api/xml )
+  topLevelDescriptor=$( curl --silent -u "admin:$adminPassword" http://localhost:$TEST_PORT/jenkins/evergreen/api/xml )
   assertEquals "Curl call to Evergreen XML API should have succeeded" 0 "$?"
 
   echo "$topLevelDescriptor" | grep -i WorkflowJob > /dev/null


### PR DESCRIPTION
[JENKINS-53494](https://issues.jenkins-ci.org/browse/JENKINS-53494)

This reverts some redirections introduced previously to get Evergreen back working.
I initially was digging into Nginx docs, but finally went to a simpler revert given our time constraint.

We also get back to exposing a single port from the Evergreen instance to be closer to prod conditions.

Will file a dedicated JIRA to reintroduce this important feature to hide the plugin manager later on (as we do not allow adding plugins by users  at this stage).