### PR TITLE
Enable prefer-template ESlint rule

### DIFF
--- a/distribution/client/.eslintrc.json
+++ b/distribution/client/.eslintrc.json
@@ -39,6 +39,7 @@
     "template-tag-spacing": "error",
     "curly": "error",
     "brace-style": "error",
-    "no-trailing-spaces": "error"
+    "no-trailing-spaces": "error",
+    "prefer-template": "error"
   }
 }

--- a/distribution/client/src/lib/update.js
+++ b/distribution/client/src/lib/update.js
@@ -121,7 +121,7 @@ class Update {
   }
 
   saveUpdateSync(manifest) {
-    logger.info('Saving a new manifest.. into ' + this.updatePath());
+    logger.info(`Saving a new manifest.. into ${this.updatePath()}`);
     fs.writeFileSync(
       this.updatePath(),
       JSON.stringify(manifest),
@@ -130,7 +130,7 @@ class Update {
   }
 
   loadUpdateSync() {
-    logger.info('Loading a new manifest.. from ' + this.updatePath());
+    logger.info(`Loading a new manifest.. from ${this.updatePath()}`);
     try {
       fs.statSync(this.updatePath());
     } catch (err) {

--- a/services/.eslintrc.json
+++ b/services/.eslintrc.json
@@ -39,6 +39,7 @@
     "template-tag-spacing": "error",
     "curly": "error",
     "brace-style": "error",
-    "no-trailing-spaces": "error"
+    "no-trailing-spaces": "error",
+    "prefer-template": "error"
   }
 }

--- a/services/acceptance/services/errortelemetry.test.js
+++ b/services/acceptance/services/errortelemetry.test.js
@@ -123,7 +123,7 @@ describe('Error Telemetry service acceptance tests', () => {
         })
           .then(res => {
             assert.ok(res);
-            assert.equal(res.status, 'OK', 'response.status should be OK but got: ' + res.status);
+            assert.equal(res.status, 'OK', `response.status should be OK but got: ${res.status}`);
           })
           .catch(err => assert.fail(err));
       });

--- a/services/src/app.js
+++ b/services/src/app.js
@@ -106,7 +106,7 @@ app.use((err, req, res, next) => {
   /* Avoid cluttering the test logs with expected errors and exceptions */
   if (process.env.NODE_ENV != 'test') {
     logger.error(err.stack);
-    logger.debug('statusCode: ' + err.statusCode + ' message: ' + err.message);
+    logger.debug(`statusCode: ${err.statusCode} message: ${err.message}`);
   }
   res.status(err.statusCode);
   res.json({ status: FAILURE, message: err.message });


### PR DESCRIPTION
For consistency and to disallow String concatenation in favor of templates.

Followup on https://github.com/jenkins-infra/evergreen/pull/229#discussion_r216488650