### PR TITLE
Update to 2.142-rc27262.2652a1b1eb90

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations: null
 spec:
   core:
-    version: 2.141-rc27251.3d1bbb807af9
+    version: 2.142-rc27262.2652a1b1eb90
   plugins:
     - groupId: io.jenkins
       artifactId: configuration-as-code
@@ -94,7 +94,7 @@ spec:
           version: 1.5.0
 status:
   core:
-    version: 2.141-rc27251.3d1bbb807af9
+    version: 2.142-rc27262.2652a1b1eb90
   plugins:
     - groupId: org.jenkins-ci.ui
       artifactId: ace-editor


### PR DESCRIPTION
Especially to update to latest remoting that silences incorrect
serialization warnings about enums, and another excessive warning.

Cf.
* https://github.com/jenkinsci/jenkins/pull/3606 and
* https://github.com/jenkinsci/remoting/pull/282