### PR TITLE
Set up module patching and use patched promise-request-retry

### DIFF
--- a/distribution/client/package.json
+++ b/distribution/client/package.json
@@ -7,7 +7,8 @@
     "client": "node src/client.js",
     "test": "npm run eslint && npm run jest",
     "eslint": "eslint src/. test/. --config .eslintrc.json",
-    "jest": "jest"
+    "jest": "jest",
+    "prepare": "patch-package"
   },
   "author": "R Tyler Croy",
   "license": "GPL-3.0",
@@ -19,6 +20,7 @@
     "html-webpack-plugin": "^3.2.0",
     "jest": "^22.4.4",
     "memfs": "^2.9.4",
+    "patch-package": "^5.1.1",
     "source-map-loader": "^0.2.4",
     "style-loader": "^0.23.0",
     "webpack": "^4.17.1",

--- a/distribution/client/patches/promise-request-retry+1.0.1.patch
+++ b/distribution/client/patches/promise-request-retry+1.0.1.patch
@@ -1,0 +1,30 @@
+patch-package
+--- a/node_modules/promise-request-retry/index.js
++++ b/node_modules/promise-request-retry/index.js
+@@ -1,7 +1,7 @@
+ 'use strict';
+ const requestPromise = require('request-promise');
+ const Promise = require('bluebird');
+-const logger = require('./modules/logger')('request-promise-retry');
++const logger  = require('winston');
+ 
+ class rpRetry {
+     static _rpRetry(options) {
+@@ -22,7 +22,16 @@ class rpRetry {
+                     logger.info(`Encountered error ${err.message} for ${options.method} request to ${options.uri}, retry count ${tryCount}`);
+                     tryCount -= 1;
+                     if (tryCount) {
+-                        return fetchDataWithRetry(tryCount);
++                        let delay = options.delay || 100; // default ms delay between retries
++                        if (options.factor) {
++                            delay *= options.factor;
++                        }
++                        return new Promise((resolve, reject) => {
++                            setTimeout(() => {
++                                logger.debug(`waiting for ${delay} ms before next retry for ${options.uri}`);
++                                resolve(fetchDataWithRetry(tryCount));
++                            }, delay);
++                        });
+                     }
+                     return Promise.reject(err);
+                 });

--- a/distribution/client/src/lib/downloader.js
+++ b/distribution/client/src/lib/downloader.js
@@ -35,7 +35,7 @@ class Downloader {
    * @param {string} the filename to output at
    * @parma {string} Optional sha256 signature to verify of the file
    */
-  static download(item, dir, fileNameToWrite, sha256) {
+  static download(item, dir, fileNameToWrite, sha256, downloadOptions = {}) {
     const itemUrl = url.parse(item);
     const itemUrlBaseName = path.basename(itemUrl.pathname);
 
@@ -61,7 +61,9 @@ class Downloader {
       resolveWithFullResponse: true,
       encoding: null,
       timeout: 120 * 1000,
-      retry: 10
+      retry: downloadOptions.retry || 10,
+      delay: downloadOptions.delay || 1000,
+      factor: downloadOptions.factor || 1.2
     };
 
     const startTime = Date.now();

--- a/distribution/client/test/downloader.test.js
+++ b/distribution/client/test/downloader.test.js
@@ -56,6 +56,17 @@ describe('the Downloader class', () => {
         await Downloader.download(toDownload, dir, 'ace-editor.hpi');
         expect(Checksum.signatureFromFile(`${dir}/ace-editor.hpi`)).toEqual(sha256);
       });
+
+      it('should not retry too fast on failed download', async () => {
+        const toDownload = 'http://nonexisting-url-yada.org/thefile';
+        const startTime = new Date();
+        try {
+          await Downloader.download(toDownload, dir, 'thefile', {retry: 4, factor: 1.1, delay: 200});
+          expect(false).toBeTruthy(); // fail(), should not reach this line.
+        } catch (e) {
+          expect(new Date() - startTime).toBeGreaterThan(4 * 200);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
While a few PRs are in flight, we can move forward without needing to go through an even heavier fork process.

Integrates https://github.com/void666/request-promise-retry/pull/6 and https://github.com/void666/request-promise-retry/pull/5 while they're not merged & released yet.