### PR TITLE
Incorporate the evergreen support distribution into the essentials.yaml

### DIFF
--- a/services/cli/ingest.js
+++ b/services/cli/ingest.js
@@ -30,8 +30,30 @@ class Ingest {
   resolveReferences() {
     let tasks = [];
 
-    const coreUrl = UrlResolver.artifactForCore(this.manifest.data.status.core);
+    this.ingest.evergreen = {
+      environments: {
+      },
+    };
 
+    this.manifest.data.spec.evergreen.environments.forEach((e) => {
+      const zipUrl = UrlResolver.evergreenRelease(e.name, e.version);
+      const record = {
+        url: zipUrl,
+        checksum: {},
+      };
+      this.ingest.evergreen.environments[e.name] = record;
+      tasks.push(
+        request(`${zipUrl}.sha256`)
+          .then((res) => {
+            Object.assign(this.ingest.evergreen.environments[e.name].checksum, {
+              type: 'sha256',
+              signature: res.split(' ')[0]
+            });
+          })
+      );
+    });
+
+    const coreUrl = UrlResolver.artifactForCore(this.manifest.data.status.core);
     this.ingest.core = {
       url: coreUrl,
       checksum: {},

--- a/services/cli/manifest.js
+++ b/services/cli/manifest.js
@@ -31,7 +31,9 @@ class Manifest {
   }
 
   saveSync() {
-    return fs.writeFileSync(this.fileName, yaml.safeDump(this.data));
+    return fs.writeFileSync(this.fileName, yaml.safeDump(this.data, {
+      noRefs: true,
+    }));
   }
 
   getPlugins() {
@@ -40,6 +42,10 @@ class Manifest {
 
   getCore() {
     return this.data.spec.core;
+  }
+
+  getEvergreen() {
+    return this.data.spec.evergreen;
   }
 
   setStatus(status) {

--- a/services/cli/url-resolver.js
+++ b/services/cli/url-resolver.js
@@ -5,6 +5,7 @@ const path = require('path');
 const INCREMENTALS = 'https://repo.jenkins-ci.org/incrementals/';
 const RELEASES     = 'https://repo.jenkins-ci.org/releases/';
 const WAR_MIRROR   = 'http://mirrors.jenkins.io/war/';
+const EVERGREEN    = 'https://github.com/jenkins-infra/evergreen/releases/download/';
 
 
 /*
@@ -12,6 +13,18 @@ const WAR_MIRROR   = 'http://mirrors.jenkins.io/war/';
  * a plugin
  */
 class UrlResolver {
+
+  /*
+   * Compute the URL for GitHub based releases of the evergreen support
+   * distributions
+   * @param {string} flavor/environment
+   * @param {version} version
+   * @retuen {string} URL to the zip file
+   */
+  static evergreenRelease(flavor, version) {
+    return `${EVERGREEN}/${version}/evergreen-${flavor}.zip`;
+  }
+
   /*
    * Compute the mirrored or Artifactory URL for the given core record
    * @param {object} corerecord from essentials.yaml

--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -3,6 +3,12 @@ metadata:
     name: jenkins-evergreen
   annotations: null
 spec:
+  evergreen:
+    environments:
+      - name: docker-cloud
+        version: v0.1.0
+      - name: aws-ec2-cloud
+        version: v0.1.0
   core:
     version: 2.142-rc27262.2652a1b1eb90
   plugins:
@@ -102,6 +108,12 @@ spec:
           artifactId: node-iterator-api
           version: 1.5.0
 status:
+  evergreen:
+    environments:
+      - name: docker-cloud
+        version: v0.1.0
+      - name: aws-ec2-cloud
+        version: v0.1.0
   core:
     version: 2.142-rc27262.2652a1b1eb90
   plugins:

--- a/services/prepare-essentials
+++ b/services/prepare-essentials
@@ -41,6 +41,7 @@ yargs.command('save',
      */
     const uc = UpdateCenter.fromFile('./update-center.json')
     let bomStatus = {
+      evergreen: Object.assign({}, manifest.getEvergreen()),
       core: {},
       plugins: [],
       environments: [],


### PR DESCRIPTION
See JENKINS-53530

- [ ] Teach the client how to report versions of the right zip file
- [ ] Teach the backend how to diff the version in the `ingest.json` with the version from the client
- [ ] Teach the client how to download the new zip file
- [ ] Teach the client how to restart :fearful: 