### PR TITLE
Actually report the level periodically from the client

### DIFF
--- a/distribution/client/src/client.js
+++ b/distribution/client/src/client.js
@@ -94,9 +94,10 @@ class Client {
 
     setInterval(() => {
       /* no-op to keep this process alive */
-      logger.info('reporting level again');
-      this.status.reportLevel();
-    }, 60 * 1000);
+      const level = this.update.getCurrentLevel();
+      logger.info('Reporting the current Update Level:', level);
+      this.status.reportLevel(level);
+    }, (5 * (60 * 1000)));
   }
 
   bootstrap() {


### PR DESCRIPTION
It helps when the function is called correctly :man-facepalming:

This function also slows the rate at which these are reported. Every five
minutes makes a bit more sense than every minute.