### PR TITLE
Consider the instance's flavor when comparing its versions to the upd…

### DIFF
--- a/services/acceptance/update-versions.test.js
+++ b/services/acceptance/update-versions.test.js
@@ -5,7 +5,6 @@
  */
 
 const fs      = require('fs');
-const logger  = require('winston');
 const request = require('request-promise');
 const h       = require('./helpers');
 
@@ -159,9 +158,7 @@ describe('versions/updates interaction acceptance tests', () => {
             }));
           });
 
-          it('should only be given the next incremnetal update', () => {
-            logger.info('TEST!');
-            logger.error(Object.values(this.updates).map(u => u.id));
+          it('should only be given the next incremental update', () => {
             return request({
               url: h.getUrl(`/update/${this.uuid}`),
               headers: { 'Authorization': this.token },

--- a/services/test/libs/auth-verifier.test.js
+++ b/services/test/libs/auth-verifier.test.js
@@ -1,0 +1,32 @@
+const AuthVerifier = require('../../src/libs/auth-verifier');
+const { Verifier } = require('@feathersjs/authentication-local');
+
+describe('Auth Verifier', () => {
+  const options = {
+    // Make server a no-op to allow construction
+    service: true,
+  };
+  it('should be insance of a verifier', () => {
+    expect((new AuthVerifier(null, options))).toBeInstanceOf(Verifier);
+  });
+
+  describe('_comparePassword()', () => {
+    const entity = {
+      uuid: 'jest-uuid',
+      curve: 'secp256k1',
+      pubkey: 'bogus',
+    };
+
+    beforeEach(() => {
+      this.verifier = new AuthVerifier(null, options);
+    });
+
+    it('should reject if the password (signed uuid) is bad', () => {
+      const signature = JSON.stringify({
+        r: 'bad',
+        s: 'signature',
+      });
+      return expect(this.verifier._comparePassword(entity, signature)).rejects.toBeInstanceOf(Error);
+    });
+  });
+});


### PR DESCRIPTION
…ate level

I believe this fixes JENKINS-53318, but I noticed this when my demo instance had
its docker-plugin, ssh-slaves, and docker-java-api plugins deleted. It had
reported the versions properly when it first installed
(https://gist.github.com/rtyler/1ee1cfc5f318a02bcbf47c59c376a384) but subsequent
update requests caused the deletion of those plugins thereby breaking the
instance.

This commit ensures that the flavor is considered when comparing versions to
also compare the versions of plugins provided by the flavor

Fixes JENKINS-53318