### PR TITLE
Re-use the HealthChecker in the boot process to determine when Jenkins is online

### DIFF
--- a/distribution/client/src/client.js
+++ b/distribution/client/src/client.js
@@ -63,6 +63,8 @@ class Client {
       .catch((err) => {
         if (err.type == 'invalid-json') {
           logger.warn('Received non-JSON response from the Update service');
+        } else if (err.code == 304) {
+          logger.debug('No updates available at this time');
         } else {
           UI.publish('Failed to query for updates!', { log: 'error', error: err });
         }

--- a/distribution/client/src/client.js
+++ b/distribution/client/src/client.js
@@ -95,11 +95,15 @@ class Client {
     }
 
     setInterval(() => {
-      /* no-op to keep this process alive */
-      const level = this.update.getCurrentLevel();
-      logger.info('Reporting the current Update Level:', level);
-      this.status.reportLevel(level);
+      /* keep this process alive */
+      this.tick();
     }, (5 * (60 * 1000)));
+  }
+
+  tick() {
+    const level = this.update.getCurrentLevel();
+    logger.debug('Reporting the current Update Level:', level);
+    this.status.reportLevel(level);
   }
 
   bootstrap() {

--- a/distribution/client/src/lib/update.js
+++ b/distribution/client/src/lib/update.js
@@ -9,12 +9,12 @@ const path    = require('path');
 const mkdirp  = require('mkdirp');
 const logger  = require('winston');
 
-const Storage     = require('./storage');
-const Downloader  = require('./downloader');
-const Supervisord = require('./supervisord');
-const UI          = require('./ui');
-const Snapshotter = require('./snapshotter');
+const Downloader    = require('./downloader');
 const HealthChecker = require('./healthchecker');
+const Storage       = require('./storage');
+const Supervisord   = require('./supervisord');
+const UI            = require('./ui');
+const Snapshotter   = require('./snapshotter');
 
 class Update {
   constructor(app, options) {
@@ -27,7 +27,15 @@ class Update {
     this.fileOptions = { encoding: 'utf8' };
     this.snapshotter = new Snapshotter();
     this.snapshotter.init(Storage.jenkinsHome());
-    this.healthChecker = new HealthChecker('http://127.0.0.1:8080'); // FIXME: define a process.env var?
+    /*
+     * This is typically going to be passed in by the Client, but some tests
+     * may not define a health checker
+     */
+    if (this.options.healthChecker) {
+      this.healthChecker = this.options.healthChecker;
+    } else {
+      this.healthChecker = new HealthChecker(process.env.JENKINS_URL || 'http://127.0.0.1:8080');
+    }
   }
 
   authenticate(uuid, token) {

--- a/node.mk
+++ b/node.mk
@@ -13,11 +13,8 @@ check: lint
 	$(MAKE) unit
 
 unit: depends
-	if [ -z "$${SKIP_TESTS}" ]; then \
-		$(NODE) npm run jest; \
-	else \
-		echo "Tests are skipped!"; \
-	fi;
+	if [ -z "$${SKIP_TESTS}" ]; then $(NODE) npm run jest; \
+	else echo "Tests are skipped!"; fi;
 
 debug-unit: depends
 	$(NODE) node --inspect-brk=0.0.0.0:9229 node_modules/.bin/jest --runInBand --bail --forceExit test/
@@ -27,9 +24,7 @@ depends: node_modules
 node_modules: package-lock.json package.json
 	# Checking to see if the directory exists because npm install updates the
 	# directory every time it runs, busting the GNU/Make cache causing rebuilds
-	if [ ! -d node_modules ]; then \
-		$(NODE) npm install; \
-	fi;
+	if [ ! -d node_modules ]; then $(NODE) npm install; fi;
 
 clean:
 	rm -rf vendor node_modules build


### PR DESCRIPTION
Without this, a client which doesn't get any new updates will never remove the booting.txt` flag and the evergreen UI will be stuck :frowning:
    
Fixes JENKINS-53594
