### PR TITLE
AWS flavor: remove the override to hit batmat's temporary backend server

### DIFF
--- a/distribution/environments/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/environments/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -61,7 +61,6 @@
               "sudo docker pull $DOCKER_IMAGE\n",
               "sudo docker run -d -p 8080:8080 -p 50000:50000 ",
               " --name jenkins-evergreen",
-              " -e EVERGREEN_ENDPOINT=http://evergreen.jenkins.io.batmat.net:8080",
               " -v $PWD/ssh-agents-private-key:/run/secrets/PRIVATE_KEY:ro",
               " -e ARTIFACT_MANAGER_S3_BUCKET_NAME=", {"Ref":"S3BucketForArtifactManager"},
               " -e AGENT_SECURITY_GROUP=", {"Ref":"EvergreenAgentSecurityGroup"},

--- a/distribution/environments/aws-ec2-cloud/README.adoc
+++ b/distribution/environments/aws-ec2-cloud/README.adoc
@@ -119,7 +119,8 @@ jq -r '.Reservations[0].Instances[].PublicIpAddress'
 TIP: `jq` is a nice tool to process JSON.
 If you do not have it installed, either install it, or just look for `PublicIpAddress` field in the json returned from the `aws ec2 describe-instances` command.
 
-Once you have the public IP, open a browser on the http://1.2.3.4:8080 URL.
+Once you have the public IP, after a few minutes
+footnote:[The master EC2 instance is being configured to run the Jenkins master. That is why even if the IP is already assigned, it could still take some more time to do additional things like installing Docker, pulling the evergreen image and have it started], open a browser on the http://1.2.3.4:8080 URL.
 This should display the Jenkins Install Wizard, asking for a secret to unlock the screen, located under `/evergreen/jenkins/home/secrets/initialAdminPassword`.
 
 To retrieve it, use the IP retrieved above in the following command:


### PR DESCRIPTION
Also add a note in the docs to let the user know they can expect some wait time to have the Evergreen instance available even after IP got assigned.