### PR TITLE
JENKINS-53631 - Fixes display of active connections number on backend

### DIFF
--- a/services/src/homepage.js
+++ b/services/src/homepage.js
@@ -30,7 +30,7 @@ module.exports = (app) => {
         updates: updates,
         levels: levels,
         instances: instances,
-        connections: app.channel('anonymous').length,
+        connections: app.channel('authenticated').length,
         commit: fs.readFileSync('./commit.txt'),
       });
     });


### PR DESCRIPTION
New instances are now connected to 'authenticated' channel.