### PR TITLE
Loglevels adjustments and message corrections

### DIFF
--- a/distribution/client/src/lib/status.js
+++ b/distribution/client/src/lib/status.js
@@ -79,7 +79,7 @@ class Status {
       },
     })
       .then(() => {
-        logger.info(`Updated the UL on the backend to ${updateLevel}`);
+        logger.info(`Currently at UL ${updateLevel}`);
       })
       .catch((err) => {
         logger.error('Failed to update the Status record with the current level', err.message, err.status);

--- a/distribution/client/src/lib/update.js
+++ b/distribution/client/src/lib/update.js
@@ -207,7 +207,7 @@ class Update {
   }
 
   saveUpdateSync(manifest) {
-    logger.info(`Saving a new manifest.. into ${this.updatePath()}`);
+    logger.info(`Saving a new manifest into ${this.updatePath()}`);
     fs.writeFileSync(
       this.updatePath(),
       JSON.stringify(manifest),
@@ -216,7 +216,7 @@ class Update {
   }
 
   loadUpdateSync() {
-    logger.info(`Loading a new manifest.. from ${this.updatePath()}`);
+    logger.debug(`Loading a new manifest from ${this.updatePath()}`);
     try {
       fs.statSync(this.updatePath());
     } catch (err) {


### PR DESCRIPTION
I adjusted this after seeing some of these logs often or not totally correct in my test instance logs:

```
info: Loading a new manifest.. from /evergreen/updates.json
info: Updated the UL on the backend to 84
[INFO][2018-09-18 01:44:41] Started DockerContainerWatchdog Asynchronous Periodic Work (from hudson.model.AsyncPeriodicWork$1 run)
[INFO][2018-09-18 01:44:41] Docker Container Watchdog has been triggered (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog execute)
[INFO][2018-09-18 01:44:41] Watchdog Statistics: Number of overall executions: 8, Executions with processing timeout: 0, Containers removed gracefully: 0, Containers removed with force: 0, Containers removal failed: 0, Nodes removed successfully: 0, Nodes removal failed: 0, Container removal average duration (gracefully): 0 ms, Container removal average duration (force): 0 ms, Average overall runtime of watchdog: 69 ms, Average runtime of container retrieval: 48 ms (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog$Statistics writeStatisticsToLog)
[INFO][2018-09-18 01:44:41] We currently have 0 nodes assigned to this Jenkins instance, which we will check (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog loadNodeMap)
[INFO][2018-09-18 01:44:41] Checking Docker Cloud docker at tcp://localhost:2375/ (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog execute)
[INFO][2018-09-18 01:44:41] Docker Container Watchdog check has been completed (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog execute)
[INFO][2018-09-18 01:44:41] Finished DockerContainerWatchdog Asynchronous Periodic Work. 11 ms (from hudson.model.AsyncPeriodicWork$1 run)
info: Loading a new manifest.. from /evergreen/updates.json
info: Loading a new manifest.. from /evergreen/updates.json
info: Updated the UL on the backend to 84
[INFO][2018-09-18 01:49:41] Started DockerContainerWatchdog Asynchronous Periodic Work (from hudson.model.AsyncPeriodicWork$1 run)
[INFO][2018-09-18 01:49:41] Docker Container Watchdog has been triggered (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog execute)
[INFO][2018-09-18 01:49:41] Watchdog Statistics: Number of overall executions: 9, Executions with processing timeout: 0, Containers removed gracefully: 0, Containers removed with force: 0, Containers removal failed: 0, Nodes removed successfully: 0, Nodes removal failed: 0, Container removal average duration (gracefully): 0 ms, Container removal average duration (force): 0 ms, Average overall runtime of watchdog: 62 ms, Average runtime of container retrieval: 44 ms (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog$Statistics writeStatisticsToLog)
[INFO][2018-09-18 01:49:41] We currently have 0 nodes assigned to this Jenkins instance, which we will check (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog loadNodeMap)
[INFO][2018-09-18 01:49:41] Checking Docker Cloud docker at tcp://localhost:2375/ (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog execute)
[INFO][2018-09-18 01:49:41] Docker Container Watchdog check has been completed (from com.nirima.jenkins.plugins.docker.DockerContainerWatchdog execute)
[INFO][2018-09-18 01:49:41] Finished DockerContainerWatchdog Asynchronous Periodic Work. 12 ms (from hudson.model.AsyncPeriodicWork$1 run)
info: Loading a new manifest.. from /evergreen/updates.json
info: Updated the UL on the backend to 84
```