### PR TITLE
Disable anonymous read by default

### DIFF
--- a/distribution/config/as-code/create-admin-user.yaml
+++ b/distribution/config/as-code/create-admin-user.yaml
@@ -8,7 +8,10 @@ jenkins:
       users:
         - id: "admin"
           password: ${JENKINS_ADMIN_PASSWORD}
-  authorizationStrategy: loggedInUsersCanDoAnything
+  authorizationStrategy:
+    loggedInUsersCanDoAnything:
+      allowAnonymousRead: false
+
   #CSRF issuer
   crumbIssuer:
     standard:

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -278,4 +278,9 @@ test_git_history_is_present() {
   assertEquals "git call to retrieve last subject should have succeeded" 0 "$?"
 }
 
+test_no_anonymous_read() {
+  result=$( curl -v -f -I http://localhost:$TEST_PORT/computer/ 2>&1 )
+  assertNotEquals "curl call to /computer should not have succeeeded" 0 "$?"
+}
+
 . ./shunit2/shunit2


### PR DESCRIPTION
Discussed with @batmat, we believe this was switched at some point, but it's a
better secure default to disallow anonymous read right now