### PR TITLE
Make sure patches are also applied for production build

### DIFF
--- a/distribution/client/package.json
+++ b/distribution/client/package.json
@@ -20,7 +20,6 @@
     "html-webpack-plugin": "^3.2.0",
     "jest": "^22.4.4",
     "memfs": "^2.9.4",
-    "patch-package": "^5.1.1",
     "source-map-loader": "^0.2.4",
     "style-loader": "^0.23.0",
     "webpack": "^4.17.1",
@@ -47,7 +46,8 @@
     "url-parse": "^1.4.3",
     "uuid": "^3.3.2",
     "winston": "^2.4.3",
-    "xmlrpc": "^1.3.2"
+    "xmlrpc": "^1.3.2",
+    "patch-package": "^5.1.1"
   },
   "jest": {
     "collectCoverage": true,

--- a/distribution/client/package.json
+++ b/distribution/client/package.json
@@ -8,7 +8,7 @@
     "test": "npm run eslint && npm run jest",
     "eslint": "eslint src/. test/. --config .eslintrc.json",
     "jest": "jest",
-    "prepare": "patch-package"
+    "postinstall": "patch-package"
   },
   "author": "R Tyler Croy",
   "license": "GPL-3.0",

--- a/distribution/packaging-list.client.txt
+++ b/distribution/packaging-list.client.txt
@@ -4,6 +4,7 @@
 ./client/config/
 ./client/src/
 ./client/src/lib/
+./client/patches/
 # Inlude the public site information
 ./client/public/
 ./client/public/docs/


### PR DESCRIPTION
See https://github.com/ds300/patch-package/issues/85

Tested only manually for now using `make run`

```
instance_1  | [INFO][2018-09-21 17:57:48] Completed initialization (from jenkins.InitReactorRunner$1 onAttained)
instance_1  | [INFO][2018-09-21 17:57:48] Jenkins is fully up and running (from hudson.WebAppMain$3 run)
instance_1  | debug: waiting for 4882.8125 ms before next retry for http://127.0.0.1:8080/instance-identity/. Next wait 6103.515625
instance_1  | debug: waiting for 4882.8125 ms before next retry for http://127.0.0.1:8080/metrics/evergreen/healthcheck. Next wait 6103.515625
instance_1  | debug: metrics healthchecking endpoint: everything looks fine: {"disk-space":{"healthy":true},"plugins":{"healthy":true,"message":"No failed plugins"},"temporary-space":{"healthy":true},"thread-deadlock":{"healthy":true}}
instance_1  | info: Jenkins healthcheck after restart succeeded! Yey.
instance_1  | [INFO][2018-09-21 17:57:53] Obtained the latest update center data file for UpdateSource default (from hudson.model.UpdateSite updateData)
instance_1  | [INFO][2018-09-21 17:57:54] Obtained the updated data file for hudson.tasks.Maven.MavenInstaller (from hudson.model.DownloadService$Downloadable load)
instance_1  | [INFO][2018-09-21 17:57:55] Obtained the updated data file for hudson.tools.JDKInstaller (from hudson.model.DownloadService$Downloadable load)
instance_1  | [INFO][2018-09-21 17:57:55] Finished Download metadata. 7,203 ms (from hudson.model.AsyncPeriodicWork$1 run)
```

As I still need to finish the rollback, associated tests will get added
in the go (we're going to probably need a step back to keep tests
maintainable: testing rollbacks with the current testing setup is likely
to need quite some work, and we'll need many more use cases to test very
soon, if not already).