### PR TITLE
Add an unused System Property which can be used to determine if we're running in Evergreen

### DIFF
--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -20,6 +20,7 @@ ENV JENKINS_UC https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 
 ENV JAVA_OPTS=\
+"-Djenkins.evergreen=true "\
 "-Djava.awt.headless=true "\
 "-Djenkins.model.Jenkins.workspacesDir=${JENKINS_VAR}/jobs/\${ITEM_FULL_NAME}/workspace "\
 "-Djenkins.model.Jenkins.buildsDir=${JENKINS_VAR}/jobs/\${ITEM_FULL_NAME}/builds "\


### PR DESCRIPTION
I expect that this will be useful further down the line for toggling specific
plugin behaviors on whether they're in the Evergreen distribution or not