### PR TITLE
[JENKINS-53499] Improve tests to avoid race condition for updates during startup

### DIFF
--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -17,7 +17,7 @@ lint: shunit2
 	$(ROOT_DIR)/tools/yamllint -s docker-compose*.yml
 	$(ROOT_DIR)/tools/yamllint -s config/as-code/*.yaml
 	$(ROOT_DIR)/tools/shellcheck -x tests/tests.sh
-	$(ROOT_DIR)/tools/shellcheck -x scripts/jenkins-evergreen.sh
+	$(ROOT_DIR)/tools/shellcheck -x scripts/*.sh
 	$(MAKE) -C environments lint
 	$(MAKE) -C client lint
 

--- a/distribution/config/supervisord.conf
+++ b/distribution/config/supervisord.conf
@@ -9,7 +9,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:evergreen-client]
 environment=HOME=%(ENV_EVERGREEN_HOME)s # Needed for Git or Node JENKINS-53856
-command=/usr/local/bin/npm run client
+command=/evergreen/scripts/start-client.sh
 directory=%(ENV_EVERGREEN_HOME)s/client
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - 'EVERGREEN_ENDPOINT=http://backend:3030'
       - 'LOG_LEVEL=debug'
       - 'INSECURE_SHOW_ADMIN_PASSWORD=true'
+      - 'DEVELOPMENT=true'
     ports:
       - '8080:80'
     depends_on:

--- a/distribution/environments/docker-cloud/config/supervisord.conf
+++ b/distribution/environments/docker-cloud/config/supervisord.conf
@@ -9,7 +9,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:evergreen-client]
 environment=HOME=%(ENV_EVERGREEN_HOME)s # Needed for Git or Node JENKINS-53856
-command=/usr/local/bin/npm run client
+command=/evergreen/scripts/start-client.sh
 directory=%(ENV_EVERGREEN_HOME)s/client
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/distribution/packaging-list.scripts.txt
+++ b/distribution/packaging-list.scripts.txt
@@ -1,3 +1,4 @@
 jenkins-evergreen.sh
 jenkins-support
 jenkins.sh
+start-client.sh

--- a/distribution/scripts/start-client.sh
+++ b/distribution/scripts/start-client.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Wrapper to force the client to wait for the backend to become available
+# Should only be useful during development
+set -euo pipefail
+
+sleepTime=8
+if [ ! -z ${DEVELOPMENT:-} ]; then
+  echo "DEVELOPMENT MODE: client will wait $sleepTime before starting, to give time to the backend to start and receive a first UL"
+  sleep $sleepTime
+else
+  echo "Client is starting up"
+fi
+
+maxAttempts=30
+
+until curl -s $EVERGREEN_ENDPOINT --output /dev/null ; do
+  maxAttempts=$(( $maxAttempts - 1 ))
+  if [[ $maxAttempts <= 0 ]]; then
+    >&2 echo "Maximum number of attempts reached: exiting"
+    exit 1
+  fi
+  >&2 echo "Backend is unavailable - sleeping for some more time"
+  sleep 1
+done
+
+exec /usr/local/bin/npm run client

--- a/distribution/scripts/start-client.sh
+++ b/distribution/scripts/start-client.sh
@@ -4,24 +4,24 @@
 # Should only be useful during development
 set -euo pipefail
 
-sleepTime=8
 if [ ! -z "${DEVELOPMENT:-}" ]; then
+  sleepTime=8
   echo "DEVELOPMENT MODE: client will wait $sleepTime before starting, to give time to the backend to start and receive a first UL"
   sleep $sleepTime
+
+  maxAttempts=30
+  until curl -s "$EVERGREEN_ENDPOINT" --output /dev/null ; do
+    maxAttempts=$(( maxAttempts - 1 ))
+    if [[ $maxAttempts -le 0 ]]; then
+      >&2 echo "Maximum number of attempts reached: exiting"
+      exit 1
+    fi
+    >&2 echo "Backend is unavailable - sleeping for some more time"
+    sleep 1
+  done
+
 else
   echo "Client is starting up"
 fi
-
-maxAttempts=30
-
-until curl -s "$EVERGREEN_ENDPOINT" --output /dev/null ; do
-  maxAttempts=$(( maxAttempts - 1 ))
-  if [[ $maxAttempts -le 0 ]]; then
-    >&2 echo "Maximum number of attempts reached: exiting"
-    exit 1
-  fi
-  >&2 echo "Backend is unavailable - sleeping for some more time"
-  sleep 1
-done
 
 exec /usr/local/bin/npm run client

--- a/distribution/scripts/start-client.sh
+++ b/distribution/scripts/start-client.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 
 # Wrapper to force the client to wait for the backend to become available
 # Should only be useful during development
 set -euo pipefail
 
 sleepTime=8
-if [ ! -z ${DEVELOPMENT:-} ]; then
+if [ ! -z "${DEVELOPMENT:-}" ]; then
   echo "DEVELOPMENT MODE: client will wait $sleepTime before starting, to give time to the backend to start and receive a first UL"
   sleep $sleepTime
 else
@@ -14,9 +14,9 @@ fi
 
 maxAttempts=30
 
-until curl -s $EVERGREEN_ENDPOINT --output /dev/null ; do
-  maxAttempts=$(( $maxAttempts - 1 ))
-  if [[ $maxAttempts <= 0 ]]; then
+until curl -s "$EVERGREEN_ENDPOINT" --output /dev/null ; do
+  maxAttempts=$(( maxAttempts - 1 ))
+  if [[ $maxAttempts -le 0 ]]; then
     >&2 echo "Maximum number of attempts reached: exiting"
     exit 1
   fi

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -16,7 +16,7 @@ JENKINS_HOME=to_override
 # Retries a few times in case of error
 upload_update_level() {
   n=0
-  until [ $n -ge 20 ]
+  until [ $n -ge 30 ]
   do
     echo "Uploading Update Level to /update service (attempt #$n):"
     curl --data-raw "{\"commit\":\"container-tests\",\"manifest\":$(cat ../services/ingest.json)}" \
@@ -26,7 +26,7 @@ upload_update_level() {
        && break
 
     n=$((n+1))
-    sleep $n
+    sleep 1
   done
 }
 
@@ -268,10 +268,8 @@ test_blueocean_default_redirect() {
 test_git_history_is_present() {
   commitCount=$( docker exec -w "$JENKINS_HOME" "$container_under_test" git rev-list --count HEAD )
   assertEquals "git call to count commits should have succeeded" 0 "$?"
-  # Depending on if ingest.json is pushed to backend before or after the client first
-  # polls the backend, we'll get 3 or 4 commits...
-  # See JENKINS-53499
-  assertTrue "[ $commitCount -ge 3 ]"
+
+  assertEquals 3  "$commitCount"
 
   docker exec -w "$JENKINS_HOME" "$container_under_test" git log --pretty=format:%s HEAD~..HEAD | \
                 grep 'Snapshot after downloads completed, before Jenkins restart' > /dev/null


### PR DESCRIPTION
[JENKINS-53499](https://issues.jenkins-ci.org/browse/JENKINS-53499)

The change here aims at making sure the client will start only when:
* the backend has started, and
* it has already received a first UL

So, we do the following:
* delay the client startup by a few seconds, only in development mode
  (by adding a startup wrapper script that will handle this)
* the test framework tries to upload the UL every seconds, instead of
  every N seconds, with N growing by one on each failed attempt.