### PR TITLE
Stop using a volume for the client

### DIFF
--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -37,5 +37,3 @@ services:
       - '8080:80'
     depends_on:
       - backend
-    volumes:
-      - ./client:/evergreen/client


### PR DESCRIPTION
Pretty sure this is why the JS->TS conversion didn't surface any CI issue, https://issues.jenkins-ci.org/browse/JENKINS-53947.

I am pretty sure **I** did this long ago :man_facepalming:.

Because of this, our tests are taking a very high risk to run against something that will actually *not* be the final image/container content.

We must remove this, and possibly add an Docker Compose override file for use with `make run`, but certainly stop using this volume mount for automated testing.