### PR TITLE
[JENKINS-53964] Drop uuid<->checksum unique constraint from versions table

### DIFF
--- a/services/acceptance/services/version.test.js
+++ b/services/acceptance/services/version.test.js
@@ -85,15 +85,27 @@ describe('Versions service acceptance tests', () => {
       });
 
       it('should allow creating redundant versions records', async () => {
-        let req = {
+        const req = {
           url: h.getUrl('/versions'),
           method: 'POST',
           headers: { 'Authorization': this.token },
           json: true,
           body: { uuid: this.reg.uuid, manifest: manifest }
         };
-        await request(req);
-        await request(req);
+        let id = null;
+        {
+          const result = await request(req);
+          expect(result.uuid).toBeTruthy();
+          expect(result.uuid).toEqual(this.reg.uuid);
+          expect(id).not.toEqual(result.id);
+          id = result.id;
+        }
+        {
+          const result = await request(req);
+          expect(result.uuid).toBeTruthy();
+          expect(result.uuid).toEqual(this.reg.uuid);
+          expect(id).not.toEqual(result.id); // show it's a new row in db, not an update or so
+        }
       });
     });
   });

--- a/services/acceptance/services/version.test.js
+++ b/services/acceptance/services/version.test.js
@@ -84,7 +84,7 @@ describe('Versions service acceptance tests', () => {
           .catch(err => expect(err.statusCode).toEqual(401));
       });
 
-      it('should disallow creating redundant versions records', async () => {
+      it('should allow creating redundant versions records', async () => {
         let req = {
           url: h.getUrl('/versions'),
           method: 'POST',
@@ -93,13 +93,7 @@ describe('Versions service acceptance tests', () => {
           body: { uuid: this.reg.uuid, manifest: manifest }
         };
         await request(req);
-
-        try {
-          await request(req);
-          expect(false).toBeTruthy();
-        } catch (err) {
-          expect(err.statusCode).toEqual(400);
-        }
+        await request(req);
       });
     });
   });

--- a/services/migrations/20181009204000-drop-uuid_checksum_uniq-key.js
+++ b/services/migrations/20181009204000-drop-uuid_checksum_uniq-key.js
@@ -1,0 +1,15 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.removeConstraint('versions', 'uuid_checksum_uniq');
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addConstraint('versions',
+      ['uuid', 'checksum'],
+      {
+        type: 'UNIQUE',
+        name: 'uuid_checksum_uniq',
+      }
+    );
+  }
+};


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-53964

I manually verified that the constraint is not here anymore with this change. 
With that fix:

```
evergreen_development=# \d+ versions;
                                                                Table "public.versions"
        Column         |           Type           | Collation | Nullable |               Default                | Storage  | Stats target | Description
-----------------------+--------------------------+-----------+----------+--------------------------------------+----------+--------------+-------------
 id                    | integer                  |           | not null | nextval('versions_id_seq'::regclass) | plain    |              |
 uuid                  | character varying(255)   |           | not null |                                      | extended |              |
 manifest              | json                     |           |          |                                      | extended |              |
 manifestSchemaVersion | integer                  |           |          |                                      | plain    |              |
 createdAt             | timestamp with time zone |           | not null |                                      | plain    |              |
 updatedAt             | timestamp with time zone |           | not null |                                      | plain    |              |
 checksum              | character varying(255)   |           | not null |                                      | extended |              |
Indexes:
    "versions_pkey" PRIMARY KEY, btree (id)

evergreen_development=# ^D\q
```

Before

```
evergreen_development=# \d+ versions;
                                                                Table "public.versions"
        Column         |           Type           | Collation | Nullable |               Default                | Storage  | Stats target | Description 
-----------------------+--------------------------+-----------+----------+--------------------------------------+----------+--------------+-------------
 id                    | integer                  |           | not null | nextval('versions_id_seq'::regclass) | plain    |              | 
 uuid                  | character varying(255)   |           | not null |                                      | extended |              | 
 manifest              | json                     |           |          |                                      | extended |              | 
 manifestSchemaVersion | integer                  |           |          |                                      | plain    |              | 
 createdAt             | timestamp with time zone |           | not null |                                      | plain    |              | 
 updatedAt             | timestamp with time zone |           | not null |                                      | plain    |              | 
 checksum              | character varying(255)   |           | not null |                                      | extended |              | 
Indexes:
    "versions_pkey" PRIMARY KEY, btree (id)
    "uuid_checksum_uniq" UNIQUE CONSTRAINT, btree (uuid, checksum)
```