### PR TITLE
[JENKINS-53811] Send also current update level along with logs

### DIFF
--- a/distribution/client/src/client.ts
+++ b/distribution/client/src/client.ts
@@ -43,7 +43,7 @@ export default class Client {
     this.healthChecker = new HealthChecker(process.env.JENKINS_URL || 'http://127.0.0.1:8080');
     this.update = new Update(this.app, { healthChecker: this.healthChecker });
     this.status = new Status(this.app, { flavor: process.env.FLAVOR });
-    this.errorTelemetry = new ErrorTelemetry(this.app, { flavor: process.env.FLAVOR });
+    this.errorTelemetry = new ErrorTelemetry(this.app, this.update, { flavor: process.env.FLAVOR });
     this.updating = false;
     // This should be overridden on bootstrap
     this.socket = null;

--- a/distribution/client/src/lib/error-telemetry.ts
+++ b/distribution/client/src/lib/error-telemetry.ts
@@ -11,6 +11,7 @@ import * as logger from 'winston'
 import path from 'path';
 
 import Storage from './storage';
+import Update from './update';
 
 export interface ErrorTelemetryOptions {
   flavor?: string,
@@ -18,13 +19,15 @@ export interface ErrorTelemetryOptions {
 
 export default class ErrorTelemetry {
   protected readonly app : any;
+  protected readonly update : Update;
   protected readonly options : ErrorTelemetryOptions;
 
   public uuid : string;
   public token : string;
 
-  constructor(app, options) {
+  constructor(app, update, options) {
     this.app = app;
+    this.update = update;
     this.options = options;
   }
 
@@ -45,6 +48,7 @@ export default class ErrorTelemetry {
       log: logDataObject,
       uuid: this.uuid,
       flavor: this.options.flavor,
+      updateLevel: this.update.getCurrentLevel()
     };
 
     return api.create(payload)

--- a/distribution/client/test/error-telemetry.test.ts
+++ b/distribution/client/test/error-telemetry.test.ts
@@ -15,13 +15,13 @@ describe('Error Telemetry Logging', () => {
 
   describe('authenticate()', () => {
     it('should store values', () => {
-      const telemetry = new ErrorTelemetry(null, null).authenticate('you-you-i-Dee', 'toe-ken-that-guy');
+      const telemetry = new ErrorTelemetry(null, null, null).authenticate('you-you-i-Dee', 'toe-ken-that-guy');
       assert.equal(telemetry.uuid, 'you-you-i-Dee');
     });
   });
 
   describe('setup() call', () => {
-    const errorTelemetryService = new ErrorTelemetry(null, null);
+    const errorTelemetryService = new ErrorTelemetry(null, null, null);
 
     let logsDir = '/evergreen/jenkins/war/logs';
     let logFile = path.join(logsDir, 'evergreen.log.0');

--- a/services/src/libs/sentry.js
+++ b/services/src/libs/sentry.js
@@ -48,6 +48,7 @@ class Sentry {
         uuid: data.uuid,
         source: data.log,
         flavor: data.flavor,
+        updateLevel: data.updateLevel
       },
     };
 


### PR DESCRIPTION
I am hoping this should help diagnosing Sentry issues, by immediately seeing which UL the instance was at when it send a given message.

Example: 
* seeing a message for an issue deemed fixed from an old UL, would orient us toward 'why this instance isn't updating?'
* seeing that message on the latest UL, where the issue triggering this message is deemed fixed already, would orient us more toward 'OK, so this is either a regression, or this is actually **not** fixed'