### PR TITLE
Ignore Visual Studio Code working directory in the evergreen tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 update-center.json
 shunit2
+.vscode/


### PR DESCRIPTION
This has been bothering me a bit since I switched to this awesome IDE, and we migrated to TS. So I thought I'd push this through to have it in rather sooner than later, as I expect this to be a no-brainer.