### PR TITLE
[JENKINS-53983] Fix per-instance tainting still serving the tainted level if you're "coming from" a lower level

### DIFF
--- a/services/Makefile
+++ b/services/Makefile
@@ -67,6 +67,10 @@ debug-run: migrate store-commit
 
 debug-db:
 	$(COMPOSE) run --rm db psql -h db -U postgres -d evergreen_development
+
+debug-test-db:
+	$(COMPOSE) run --rm db psql -h db -U postgres -d evergreen_test
+
 ##############################################################
 ##
 

--- a/services/acceptance/update-versions.test.js
+++ b/services/acceptance/update-versions.test.js
@@ -120,13 +120,13 @@ describe('versions/updates interaction acceptance tests', () => {
           return request(payload)
             /* Making the assumption in tests that a legit update is -1 */
             .then(r => expect(r.meta.level).toEqual(taintedLevel - 1))
-            .then ( () => {
+            .then(() => {
               // let's check that a subsequent request with the rolled back level does not yield the tainted one
+              // (we're now expecting an HTTP-304)
               payload.qs.level = taintedLevel - 1;
+              logger.debug(`Testing second case with ${JSON.stringify(payload)}`);
               return request(payload);
-            }).then ( r => {
-              expect(r.meta.level).toEqual(taintedLevel - 1);
-            });
+            }).catch(err => expect(err.statusCode).toBe(304));
         });
       });
 


### PR DESCRIPTION
[JENKINS-53983](https://issues.jenkins-ci.org/browse/JENKINS-53983)

This fixes the issue that would return the next UL, even if per-instance tainted, once the instance is back to the previous one. Hence for example making an instance go like UL30=>UL31=>UL30=>UL31=>UL30=>UL31=>etc.

The code for computing the next UL was deeply changed. So a careful review would be good. I added a lot of comments to explain the whole thing, but the code itself is now much shorter. 