### PR TITLE
Reenable test now sse-gateway:1.16 has been shipped

### DIFF
--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -86,13 +86,10 @@ test_war_is_not_exploded_under_jenkins_home() {
 }
 test_logs_are_not_under_jenkins_home() {
 
-  # Test skipped until https://github.com/jenkinsci/sse-gateway-plugin/pull/25 is released
-  startSkipping
   # shellcheck disable=SC2016
   result=$( docker exec "$container_under_test" bash -c 'ls $JENKINS_HOME/logs' 2>&1 )
   assertNotEquals "ls should return non zero for logs dir" "0" "$?"
   assertEquals "ls should not find logs directory" "ls: /evergreen/jenkins/home/logs: No such file or directory" "$result"
-  endSkipping
 }
 
 test_jenkins_logs_is_found_on_disk() {

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -89,7 +89,7 @@ test_logs_are_not_under_jenkins_home() {
   # shellcheck disable=SC2016
   result=$( docker exec "$container_under_test" bash -c 'ls $JENKINS_HOME/logs' 2>&1 )
   assertNotEquals "ls should return non zero for logs dir" "0" "$?"
-  assertEquals "ls should not find logs directory" "ls: /evergreen/jenkins/home/logs: No such file or directory" "$result"
+  assertEquals "ls should not find logs directory" "ls: $JENKINS_HOME/logs: No such file or directory" "$result"
 }
 
 test_jenkins_logs_is_found_on_disk() {


### PR DESCRIPTION
Was waiting on https://github.com/jenkinsci/sse-gateway-plugin/pull/25, finally just shipped with Blue Ocean 1.9.0, pushed through #318 