### PR TITLE
[JENKINS-54056] Update Level Automated Rollback

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,6 +142,17 @@ pipeline {
                       }
                   }
                 }
+                stage('Rollback testing') {
+                  agent { label 'linux' }
+                  steps {
+                      sh 'make -C distribution clean rollback-check'
+                  }
+                  post {
+                      always {
+                          archiveArtifacts artifacts: '**/build/tests-run*/**'
+                      }
+                  }
+                }
                 stage('AWS Cloud image (smokes)') {
                   agent { label 'linux' }
                   steps {

--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -15,8 +15,10 @@ all: check container
 
 lint: shunit2
 	$(ROOT_DIR)/tools/yamllint -s docker-compose*.yml
+	$(ROOT_DIR)/tools/yamllint -s ./tests/environments/*/docker-compose*.yml
 	$(ROOT_DIR)/tools/yamllint -s config/as-code/*.yaml
-	$(ROOT_DIR)/tools/shellcheck -x tests/tests.sh
+	$(ROOT_DIR)/tools/shellcheck -x tests/*.sh
+	$(ROOT_DIR)/tools/jsonlint --quiet ./tests/rollback/*.json
 	$(ROOT_DIR)/tools/shellcheck -x scripts/*.sh
 	$(MAKE) -C environments lint
 	$(MAKE) -C client lint

--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -82,7 +82,11 @@ container-check-prereqs: shunit2 ./tests/tests.sh ./tests/offline-tests.sh creat
 	$(MAKE) -C ../services lint
 	$(MAKE) -C ../services dump generate-ingest
 
-container-check: docker-cloud-container-check aws-cloud-container-check
+container-check: docker-cloud-container-check aws-cloud-container-check rollback-check
+
+# Only checking it on docker-cloud.
+rollback-check: containers container-check-prereqs
+	ENVIRONMENT=docker-cloud ./tests/rollback-tests.sh
 
 docker-cloud-container-check: containers container-check-prereqs
 	ENVIRONMENT=docker-cloud ./tests/offline-tests.sh

--- a/distribution/client/src/client.ts
+++ b/distribution/client/src/client.ts
@@ -97,7 +97,9 @@ export default class Client {
       UI.publish('Jenkins appears to be online', { log: 'info' });
       Storage.removeBootingFlag();
     }).catch((error) => {
-      UI.publish('Jenkins appears to be in an unhealthy state!', { log: 'error' });
+      const errorMessage = 'Jenkins appears to be in an unhealthy state (startup auto-healthcheck)!'
+      logger.error(errorMessage);
+      UI.publish(errorMessage, { log: 'error' });
     });
 
     cron.runDaily('post-status', () => {

--- a/distribution/client/src/client.ts
+++ b/distribution/client/src/client.ts
@@ -93,13 +93,11 @@ export default class Client {
 
     this.runUpdates();
 
-    this.healthChecker.check().then((state) => {
-      if (state.healthy) {
-        UI.publish('Jenkins appears to be online', { log: 'info' });
-        Storage.removeBootingFlag();
-      } else {
-        UI.publish('Jenkins appears to be in an unhealthy state!', { log: 'error' });
-      }
+    this.healthChecker.check().then(() => {
+      UI.publish('Jenkins appears to be online', { log: 'info' });
+      Storage.removeBootingFlag();
+    }).catch((error) => {
+      UI.publish('Jenkins appears to be in an unhealthy state!', { log: 'error' });
     });
 
     cron.runDaily('post-status', () => {

--- a/distribution/client/src/client.ts
+++ b/distribution/client/src/client.ts
@@ -41,8 +41,8 @@ export default class Client {
     this.app = feathers();
     this.reg = new Registration(this.app);
     this.healthChecker = new HealthChecker(process.env.JENKINS_URL || 'http://127.0.0.1:8080');
-    this.update = new Update(this.app, { healthChecker: this.healthChecker }), { status: this.status };
     this.status = new Status(this.app, { flavor: process.env.FLAVOR });
+    this.update = new Update(this.app, { healthChecker: this.healthChecker, status: this.status });
     this.errorTelemetry = new ErrorTelemetry(this.app, this.update, { flavor: process.env.FLAVOR });
     this.updating = false;
     // This should be overridden on bootstrap

--- a/distribution/client/src/client.ts
+++ b/distribution/client/src/client.ts
@@ -97,9 +97,7 @@ export default class Client {
       UI.publish('Jenkins appears to be online', { log: 'info' });
       Storage.removeBootingFlag();
     }).catch((error) => {
-      const errorMessage = 'Jenkins appears to be in an unhealthy state (startup auto-healthcheck)!'
-      logger.error(errorMessage);
-      UI.publish(errorMessage, { log: 'error' });
+      UI.publish('Jenkins appears to be in an unhealthy state (startup auto-healthcheck)!', { log: 'error' });
     });
 
     cron.runDaily('post-status', () => {

--- a/distribution/client/src/client.ts
+++ b/distribution/client/src/client.ts
@@ -41,7 +41,7 @@ export default class Client {
     this.app = feathers();
     this.reg = new Registration(this.app);
     this.healthChecker = new HealthChecker(process.env.JENKINS_URL || 'http://127.0.0.1:8080');
-    this.update = new Update(this.app, { healthChecker: this.healthChecker });
+    this.update = new Update(this.app, { healthChecker: this.healthChecker }), { status: this.status };
     this.status = new Status(this.app, { flavor: process.env.FLAVOR });
     this.errorTelemetry = new ErrorTelemetry(this.app, this.update, { flavor: process.env.FLAVOR });
     this.updating = false;

--- a/distribution/client/src/lib/healthchecker.ts
+++ b/distribution/client/src/lib/healthchecker.ts
@@ -59,14 +59,7 @@ export default class HealthChecker {
     return Promise.all(checks)
       .then( () => {
         return {
-          healthy: true,
           message: 'All checks were successful. Instance deemed healthy.'
-        };
-      })
-      .catch( error => {
-        return {
-          healthy: false,
-          message: `Something went wrong: ${error}`
         };
       });
 

--- a/distribution/client/src/lib/supervisord.ts
+++ b/distribution/client/src/lib/supervisord.ts
@@ -50,7 +50,7 @@ export default class Supervisord {
   static startProcess(name) {
     logger.info(`[supervisord] Starting ${name} process`);
     return new Promise((resolve, reject) => {
-      client.methodCall('supervisor.startProcess', [name], (e, value) => {
+      client.methodCall('supervisor.startProcess', [name,true], (e, value) => {
         if (e) {
           return reject(e);
         }
@@ -62,7 +62,7 @@ export default class Supervisord {
   static stopProcess(name) {
     logger.info(`[supervisord] Stopping ${name} process`);
     return new Promise((resolve, reject) => {
-      client.methodCall('supervisor.stopProcess', [name], (e, value) => {
+      client.methodCall('supervisor.stopProcess', [name,true], (e, value) => {
         if (e) {
           return reject(e);
         }
@@ -77,22 +77,6 @@ export default class Supervisord {
       await this.stopProcess(name);
     }
 
-    // During testing, it seemed like the restart call done to Supervisord could take some time
-    // for Jenkins to actually start restarting.
-    // This was causing issues, because then the healthcheck done after the restart would actually
-    // happen on the *current* version of Jenkins, running the current UL, and not the one we are
-    // about to restart "on".
-    // So we give a few seconds to actually wait for Jenkins to initiate restart so that the following
-    // healthchecks or anything else happen on Jenkins *after* restart, and not somehow during or /just before/ it.
-    return this.startProcess(name)
-      .then(() => {
-        logger.info('Waiting a few seconds while Jenkins restart is being initiated before continuing...')
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            resolve(true);
-          }, 5000);
-        });
-      });
-
+    return this.startProcess(name);
   }
 }

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -158,21 +158,16 @@ export default class Update {
     logger.info(`Triggering update with tasks: ${tasks}`);
 
     return Promise.all(tasks).then(() => {
-
       UI.publish('All downloads completed, snapshotting data before restart');
       this.snapshotter.snapshot(`UL${this.getCurrentLevel()}->UL${updates.meta.level} Snapshot after downloads completed, before Jenkins restart`);
       this.saveUpdateSync(updates);
       UI.publish('All downloads completed and snapshotting done, restarting Jenkins');
 
     }).then( () => {
-
       return this.restartJenkins();
-
     }).finally( () => {
-
       this.updateInProgress = null;
       return true;
-
     });
   }
 
@@ -212,7 +207,7 @@ export default class Update {
 
         UI.publish(`Jenkins detected as unhealthy. Rolling back to previous update level (${error}).`, {log: 'warn'});
 
-        return this.revertToPreviousUpdateLevel(); // FIXME: async issue!
+        return this.revertToPreviousUpdateLevel();
 
       }).catch((error) => { // second time wrong, stop trying and just holler for help
 

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -231,8 +231,20 @@ export default class Update {
   /*
    * 1) Taint current level
    * 2) query and trigger a new update
-   *    (failing UL has been marked tainted for the instance, so should be served the/a previous UL)
-   * FIXME: 'the/a previous UL' => current code will serve "a" UL. We actually want "the"
+   *    (failing UL has been marked tainted for the instance, so *should* be served the previous UL)
+   *
+   * FIXME: the served UL when rolling back could (rarely, but still) be different from the actual previous one before failed upgrade.
+   * Example:
+   *
+   * * an instance is on UL50
+   * * for some reason, this UL is globally tainted after the fact
+   * * a new UL51 is pushed
+   * * the instance updates to UL51, but fails, so initiate a rollback
+   * * it will per-instance taint UL51, then asks for where to go
+   * * the server will tell the instance to go to UL49, not UL50. So technically, this could cause issues,
+   *   especially with the data snapshoting system and the associated restore...
+   * For now, we've ignored this issue, and granted this should almost never actually happen given host fast updates are pushed.
+   * But it's algorithmically and generally still _possible_.
    */
   revertToPreviousUpdateLevel() {
     this.snapshotter.revertToLevelBefore(this.getCurrentLevel()); // TODO test this

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -51,7 +51,11 @@ export default class Update {
       this.healthChecker = new HealthChecker(process.env.JENKINS_URL || 'http://127.0.0.1:8080');
     }
 
+    if(!this.options.status) {
+      throw new Error('Missing required status attribute');
+    }
     this.status = this.options.status;
+
   }
 
   authenticate(uuid, token) {

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -218,12 +218,11 @@ export default class Update {
 
         // Quick notice sketch, but I do think we need a very complete and informative message
         const failedToRollbackMessage =
-          'Ooh noes :-(. We are terribly sorry but it looks like Jenkins failed to ' +
-          'upgrade, but even after the automated rollback we were unable to bring ' +
-          'to life. Please report this issue to the Jenkins Evergreen team. ' +
-          'Do not shutdown your instance as we have been notified of this failure ' +
-          'and are trying to understand what went wrong to push a new update that ' +
-          'will fix things.';
+          'Ooh noes :-(. We are terribly sorry but it looks like Jenkins failed to upgrade, but even after the automated rollback we ' +
+          'were unable to bring it back to life. Please report this issue to the Jenkins Evergreen issue tracker at ' +
+          'https://github.com/jenkins-infra/evergreen/issues. ' +
+          'Do not shutdown your instance as we have been notified of this failure and are trying to understand what went wrong to ' +
+          'push a new update to fix the problem.';
         UI.publish(failedToRollbackMessage, { log: 'error' });
 
         // Not throwing an Error here as we want the client to keep running and ready

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -54,7 +54,7 @@ export default class Update {
     if (this.options.status) {
       this.status = this.options.status;
     } else {
-      this.status = this.status = new Status(this.app, { flavor: process.env.FLAVOR });
+      this.status = new Status(this.app, { flavor: process.env.FLAVOR });
     }
   }
 

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -70,7 +70,7 @@ export default class Update {
     });
   }
 
-  async taintUpdateLevel(levelToTaint) {
+  async taintUpdateLevel(levelToTaint?: number) {
     let toBeTaintedLevel = levelToTaint;
     if (!toBeTaintedLevel) {
       toBeTaintedLevel = this.getCurrentLevel();

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -51,11 +51,11 @@ export default class Update {
       this.healthChecker = new HealthChecker(process.env.JENKINS_URL || 'http://127.0.0.1:8080');
     }
 
-    if(!this.options.status) {
-      throw new Error('Missing required status attribute');
+    if (this.options.status) {
+      this.status = this.options.status;
+    } else {
+      this.status = this.status = new Status(this.app, { flavor: process.env.FLAVOR });
     }
-    this.status = this.options.status;
-
   }
 
   authenticate(uuid, token) {

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -282,7 +282,7 @@ export default class Update {
   recordUpdateLevel(manifest) {
     logger.debug('Storing Update Level for auditability');
     const level = this.getCurrentLevel();
-    const log = {timestamp: new Date(), updateLevel: level};
+    const log = {timestamp: new Date(), updateLevel: level, 'manifest': manifest};
     const logLine = JSON.stringify(log);
 
     fs.appendFileSync(this.auditLogPath(),

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -194,7 +194,6 @@ export default class Update {
   restartJenkins() {
 
     const jenkinsIsRestarting = Supervisord.restartProcess('jenkins');
-
     UI.publish('Jenkins is being restarted, health checking!', { log: 'info' });
 
     return jenkinsIsRestarting
@@ -206,7 +205,6 @@ export default class Update {
       }).catch((error) => { // first catch, try rolling back
 
         UI.publish(`Jenkins detected as unhealthy. Rolling back to previous update level (${error}).`, {log: 'warn'});
-
         return this.revertToPreviousUpdateLevel();
 
       }).catch((error) => { // second time wrong, stop trying and just holler for help

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -106,8 +106,9 @@ export default class Update {
       // Setting this to a timestamp to make a timeout in the future
       this.updateInProgress = new Date();
     }
-
-    UI.publish('Starting to apply updates');
+    const applyUpdatesMessage = 'Starting to apply updates';
+    logger.info(applyUpdatesMessage)
+    UI.publish(applyUpdatesMessage);
 
     const tasks = [];
 

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -149,7 +149,7 @@ export default class Update {
     }
 
     if (tasks.length == 0) {
-      logger.warn('No actionable tasks');
+      logger.warn('No actionable tasks during upgrade process');
       this.updateInProgress = null;
       this.saveUpdateSync(updates);
       return true;

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -118,9 +118,7 @@ export default class Update {
       // Setting this to a timestamp to make a timeout in the future
       this.updateInProgress = new Date();
     }
-    const applyUpdatesMessage = 'Starting to apply updates';
-    logger.info(applyUpdatesMessage)
-    UI.publish(applyUpdatesMessage);
+    UI.publish('Starting to apply updates', { log: 'info' });
 
     const tasks = [];
 
@@ -202,9 +200,7 @@ export default class Update {
 
     const jenkinsIsRestarting = Supervisord.restartProcess('jenkins');
 
-    const messageWhileRestarting = 'Jenkins is being restarted, health checking!';
-    UI.publish(messageWhileRestarting);
-    logger.info(messageWhileRestarting);
+    UI.publish('Jenkins is being restarted, health checking!', { log: 'info' });
 
     return jenkinsIsRestarting
       .then(() => this.healthChecker.check())
@@ -214,9 +210,7 @@ export default class Update {
 
       }).catch((error) => { // first catch, try rolling back
 
-        const errorMessage = `Jenkins detected as unhealthy. Rolling back to previous update level (${error}).`;
-        logger.warn(errorMessage);
-        UI.publish(errorMessage);
+        UI.publish(`Jenkins detected as unhealthy. Rolling back to previous update level (${error}).`, {log: 'warn'});
 
         return this.revertToPreviousUpdateLevel(); // FIXME: async issue!
 
@@ -230,8 +224,7 @@ export default class Update {
           'Do not shutdown your instance as we have been notified of this failure ' +
           'and are trying to understand what went wrong to push a new update that ' +
           'will fix things.';
-        logger.error(failedToRollbackMessage, error);
-        UI.publish(failedToRollbackMessage);
+        UI.publish(failedToRollbackMessage, { log: 'error' });
 
         // Not throwing an Error here as we want the client to keep running and ready
         // since the next available UL _might_ fix the issue

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -202,8 +202,8 @@ export default class Update {
       }).catch( (error) => { // first catch, try rolling back
 
         const errorMessage = `Jenkins detected as unhealthy. Rolling back to previous update level (${error}).`;
-        UI.publish(errorMessage);
         logger.warn(errorMessage);
+        UI.publish(errorMessage);
 
         return this.revertToPreviousUpdateLevel(); // FIXME: async issue!
 

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -196,7 +196,6 @@ export default class Update {
     return this.healthChecker.check()
       .then( healthState => {
         logger.info('Jenkins healthcheck after restart succeeded! Yey.');
-        Storage.removeBootingFlag();
         return true;
 
       }).catch( (error) => { // first catch, try rolling back

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -110,6 +110,10 @@ export default class Update {
   async applyUpdates(updates, forceUpdate?: boolean) {
     if (forceUpdate) {
       logger.warn('Forced update (expected during a rollback)');
+      if(!this.updateInProgress) {
+        logger.warn('No value for updateInProgress during a forced update, that is unexpected, setting a new value!');
+        this.updateInProgress = new Date();
+      }
     }
     else if (this.updateInProgress || (!updates)) {
       logger.warn('applyUpdates request ignored: update already in progress!');

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -187,18 +187,20 @@ export default class Update {
      * how to report that borked case in a clear way
   */
   restartJenkins() {
-    Supervisord.restartProcess('jenkins');
+
+    const jenkinsIsRestarting = Supervisord.restartProcess('jenkins');
 
     const messageWhileRestarting = 'Jenkins is being restarted, health checking!';
     UI.publish(messageWhileRestarting);
     logger.info(messageWhileRestarting);
 
-    return this.healthChecker.check()
-      .then( healthState => {
+    return jenkinsIsRestarting
+      .then(() => this.healthChecker.check())
+      .then(() => {
         logger.info('Jenkins healthcheck after restart succeeded! Yey.');
         return true;
 
-      }).catch( (error) => { // first catch, try rolling back
+      }).catch((error) => { // first catch, try rolling back
 
         const errorMessage = `Jenkins detected as unhealthy. Rolling back to previous update level (${error}).`;
         logger.warn(errorMessage);

--- a/distribution/client/src/lib/update.ts
+++ b/distribution/client/src/lib/update.ts
@@ -186,7 +186,7 @@ export default class Update {
        while it's not been yet marked as tainted in the backend?
      * how to report that borked case in a clear way
   */
-  restartJenkins(rollingBack?: boolean) { // number param instead to detect an unruly recursive call depth (must never be more than one recursive call)
+  restartJenkins() {
     Supervisord.restartProcess('jenkins');
 
     const messageWhileRestarting = 'Jenkins is being restarted, health checking!';

--- a/distribution/client/test/update.rollback.test.ts
+++ b/distribution/client/test/update.rollback.test.ts
@@ -1,4 +1,3 @@
-jest.mock('../src/lib/supervisord');
 
 import feathers      from '@feathersjs/feathers';
 import mkdirp        from 'mkdirp';
@@ -6,6 +5,10 @@ import tmp           from 'tmp';
 import Update        from '../src/lib/update';
 import HealthChecker from '../src/lib/healthchecker';
 import Storage       from '../src/lib/storage';
+import Status        from '../src/lib/status';
+import Supervisord   from '../src/lib/supervisord';
+
+jest.mock('../src/lib/supervisord');
 
 describe('The update module', () => {
   let app = null;
@@ -24,6 +27,14 @@ describe('The update module', () => {
       return Promise.resolve({ message: 'fake' });
     });
     update.taintUpdateLevel = jest.fn(() => {
+      return Promise.resolve(true);
+    });
+    update.status = new Status(app);
+    update.status.reportVersions = jest.fn(() => {
+      return Promise.resolve(true);
+    });
+
+    Supervisord.restartProcess = jest.fn(() => {
       return Promise.resolve(true);
     });
   });
@@ -102,6 +113,7 @@ describe('The update module', () => {
       // THEN we get an automated revert
       expect(update.taintUpdateLevel).toHaveBeenCalled();
       expect(update.query).toHaveBeenCalled();
+      expect(update.status.reportVersions).toHaveBeenCalled();
       expect(update.getCurrentLevel()).toBe(1);
 
     });

--- a/distribution/client/test/update.rollback.test.ts
+++ b/distribution/client/test/update.rollback.test.ts
@@ -1,0 +1,102 @@
+jest.mock('../src/lib/supervisord');
+
+import feathers      from '@feathersjs/feathers';
+import mkdirp        from 'mkdirp';
+import tmp           from 'tmp';
+import Update        from '../src/lib/update';
+import HealthChecker from '../src/lib/healthchecker';
+import Storage       from '../src/lib/storage';
+
+describe('The update module', () => {
+  let app = null;
+  let update = null;
+
+  beforeEach(() => {
+    const evergreenHome = tmp.dirSync({ unsafeCleanup: true }).name;
+    process.env.EVERGREEN_DATA = evergreenHome;
+    Storage.homeDirectory = (() => evergreenHome);
+    mkdirp.sync(Storage.jenkinsHome());
+
+    app = feathers();
+    update = new Update(app);
+    update.healthChecker = new HealthChecker('http://127.0.0.1:8080/', { delay: 50, retry: 5 });
+    update.healthChecker.check = jest.fn(() => {
+      return Promise.resolve({ message: 'fake' });
+    });
+    update.revertToPreviousUpdateLevel = jest.fn(() => {
+      return true;
+    });
+  });
+
+
+  describe('applyUpdates()', () => {
+    let manifest = null;
+    beforeEach(() => {
+      update.updateInProgress = false;
+      manifest = {
+        meta: { level: 1 },
+        plugins: {},
+      };
+    });
+
+    // Tests TODO: 
+    // * check we do not rollback UL0
+    // * no rolling back twice
+    // * when rolling back, applyUpdates can actually be called by itself to trigger the rollback
+
+    it('should rollback if healthcheck goes wrong (and revert works)', async () => {
+
+      // ====================================================
+      // GIVEN a good update from initial/default UL0 to UL1
+      expect(update.getCurrentLevel()).toBe(0);
+      
+      const ul1 = Object.assign({},
+        manifest,
+        {
+          meta: { level: 1 },
+          plugins: {
+            updates: [
+              {
+                artifactId: 'daily-quote',
+                url: 'http://updates.jenkins-ci.org/download/plugins/daily-quote/1.0/daily-quote.hpi',
+                checksum: { signature: 'e0e6bf16f76f1627c1aa296d796c6cc55cdcca838ae5d144f698524b488a72c1' }
+              }
+            ]
+          }
+        }
+        );
+        const result1 = await update.applyUpdates(ul1);
+        
+        // Update to UL1 went OK
+        expect(update.getCurrentLevel()).toBe(1);
+        expect(result1).toBe(true);
+        expect(update.healthChecker.check).toHaveBeenCalled();
+        
+      // ========================
+      // WHEN a bad update to UL2
+      
+      const ul2 = Object.assign({}, ul1, { meta: { level: 2 } })
+      ul2.plugins.updates = [
+        {
+          artifactId: 'evergreen',
+          url: 'https://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen/1.0-rc58.a9ecd200b39a/evergreen-1.0-rc58.a9ecd200b39a.hpi',
+          checksum: { signature: 'd5fd13e57eb2cfb030bef235206f1b7c97fec5d158c2e8a0106cf8a6b0617de7' }
+        }
+      ];
+
+      // change the healthchecking mock to force a failure, hence a revert below
+      update.healthChecker.check.mockImplementationOnce(() => {return Promise.reject(new Error('forced mock failure for healthchecking'))});
+      
+      expect(update.revertToPreviousUpdateLevel).not.toHaveBeenCalled(); // not yet, let's just double-check
+      
+      // update to broken UL2 (as healthchecking is stubbed above to fail)
+      const result2 = await update.applyUpdates(ul2);
+      
+      // ===============================
+      // THEN we get an automated revert
+      expect(update.revertToPreviousUpdateLevel).toHaveBeenCalled();
+
+    });
+
+  });
+});

--- a/distribution/client/test/update.rollback.test.ts
+++ b/distribution/client/test/update.rollback.test.ts
@@ -114,6 +114,7 @@ describe('The update module', () => {
       expect(update.taintUpdateLevel).toHaveBeenCalled();
       expect(update.query).toHaveBeenCalled();
       expect(update.status.reportVersions).toHaveBeenCalled();
+      expect(Supervisord.restartProcess).toHaveBeenCalled();
       expect(update.getCurrentLevel()).toBe(1);
 
     });

--- a/distribution/client/test/update.test.ts
+++ b/distribution/client/test/update.test.ts
@@ -1,4 +1,3 @@
-jest.mock('../src/lib/supervisord');
 jest.mock('../src/lib/downloader');
 
 const fs            = require('fs');
@@ -17,6 +16,7 @@ import Downloader from '../src/lib/downloader';
 describe('The update module', () => {
   let app = null;
   let update = null;
+  let restartCalled = false;
 
   beforeEach( () => {
     const evergreenHome = tmp.dirSync({unsafeCleanup: true}).name;
@@ -27,6 +27,14 @@ describe('The update module', () => {
     app = feathers();
     update = new Update(app);
     update.healthChecker = new HealthChecker('http://127.0.0.1:8080/', { delay: 50, retry: 5});
+    update.healthChecker.check = () => {
+      return Promise.resolve({ healthy:true, message: 'fake'});
+    };
+    restartCalled = false;
+    update.restartJenkins = () => {
+      restartCalled = true;
+      return Promise.resolve(true);
+    };
   });
 
   describe('authenticate()', () => {
@@ -129,7 +137,7 @@ describe('The update module', () => {
       manifest.plugins.deletes.forEach((filename) => {
         expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).resolves.toBeFalsy();
       });
-      expect(Supervisord.restartProcess).toHaveBeenCalled();
+      expect(restartCalled).toBeTruthy();
     });
 
     it ('should execute updates if passed in with no deletes', async () => {
@@ -152,7 +160,7 @@ describe('The update module', () => {
       expect(response).toBeTruthy();
       expect(update.updateInProgress).toBeFalsy();
       expect(h.checkFileExists(`${pluginPath}/daily-quote.hpi`)).resolves.toBeTruthy();
-      expect(Supervisord.restartProcess).toHaveBeenCalled();
+      expect(restartCalled).toBeTruthy();
     });
 
     it('should execute both updates and deletes if both passed in', async () => {

--- a/distribution/client/test/update.test.ts
+++ b/distribution/client/test/update.test.ts
@@ -83,7 +83,7 @@ describe('The update module', () => {
   });
 
   describe('applyUpdates()', () => {
-    let manifest = null;
+    let manifest : any = {};
     beforeEach(() => {
       update.updateInProgress = false;
       manifest = {
@@ -105,7 +105,8 @@ describe('The update module', () => {
 
     it('should not reject on no plugin updates', async () => {
       const response = await update.applyUpdates(manifest);
-      expect(response).toBeFalsy();
+      expect(response).toBe(true);
+
       expect(update.updateInProgress).toBeFalsy();
     });
 

--- a/distribution/client/tsconfig.json
+++ b/distribution/client/tsconfig.json
@@ -3,14 +3,13 @@
     "allowJs": true,
     "alwaysStrict" : true,
     "outDir": "./build",
-    "module" : "commonjs",
     "skipLibCheck": true,
-    "lib" : ["es2015"],
+    "lib" : ["es2018"],
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "importHelpers" : true,
-    "target": "es2015",
+    "target": "es2018",
     "sourceMap": true
   },
   "include": [

--- a/distribution/docker-compose.yml
+++ b/distribution/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - 'LOG_LEVEL=debug'
       - 'INSECURE_SHOW_ADMIN_PASSWORD=true'
       - 'DEVELOPMENT=true'
+      - 'PROCESS_RETRY_OVERRIDE=10'
     ports:
       - '8080:80'
     depends_on:

--- a/distribution/tests/offline-tests.sh
+++ b/distribution/tests/offline-tests.sh
@@ -4,16 +4,12 @@
 current_directory=$(dirname "$0")
 export PATH="$current_directory/../../tools:$PATH"
 
-JENKINS_HOME=to_override
-
 # shellcheck source=tests/utilities
 . "$current_directory/utilities"
 
 
 oneTimeSetUp() {
   setup_container_under_test
-  # shellcheck disable=SC2016
-  JENKINS_HOME="$( docker exec "$container_under_test" bash -c 'echo $JENKINS_HOME' )"
 }
 
 # JENKINS-49864
@@ -35,7 +31,7 @@ test_not_root() {
 
   docker exec "$container_under_test" ps -o user= -o comm= | \
     grep -E 'jenkins|npm' | \
-    while read process_user
+    while read -r process_user
   do
     currentUser=$( echo "$process_user" | awk '{print $1}' )
     assertEquals "User for '$process_user' should be jenkins" "jenkins" "$currentUser"
@@ -70,7 +66,7 @@ test_jep_307() {
 test_INSECURE_SHOW_ADMIN_PASSWORD_can_be_unset() {
   # Avoid executing this for the base image
   if [ ! -z "${ENVIRONMENT}" ]; then
-    result=$( docker run --rm jenkins/evergreen:$ENVIRONMENT /evergreen/scripts/jenkins-evergreen.sh )
+    result=$( docker run --rm "jenkins/evergreen:$ENVIRONMENT" /evergreen/scripts/jenkins-evergreen.sh )
     # Expected to fail, but because war is missing. Admin password must have been generated,
     # and final expected error line is "Error: Unable to access jarfile /evergreen/jenkins/home/jenkins.war"
     assertNotEquals "Should have failed to start up (war is absent)" "0" "$?"

--- a/distribution/tests/rollback-tests.sh
+++ b/distribution/tests/rollback-tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Note: would have used set -euo pipefail, but ./shunit2 unfortunately fails hard with this :-(.
+
+current_directory=$(dirname "$0")
+# TODO: use the $( cd blah ; ... ) trick to un-relativize path below
+export PATH="$current_directory/../../tools:$PATH"
+
+echo "Debugging: PATH=***$PATH***"
+
+JENKINS_HOME=to_override
+
+# shellcheck source=tests/utilities
+. "$current_directory/utilities"
+
+oneTimeSetUp() {
+  setup_container_under_test
+
+  echo "PWD=$( pwd )"
+
+  upload_update_level "./tests/rollback/1-ingest-ok.json"
+
+  wait_for_jenkins
+  # shellcheck disable=SC2016
+  JENKINS_HOME="$( docker exec "$container_under_test" bash -c 'echo $JENKINS_HOME' )"
+}
+
+test_rollback() {
+
+  # Check UL is the correct one (UL 1 or UL 2?!)
+  docker exec "$container_under_test" bash -c 'ls $EVERGREEN_DATA'
+  # extract 2 from `"level":2` from the updates.json file
+  correctUL=$( docker exec "$container_under_test" bash -c 'cat $EVERGREEN_DATA/updates.json' | \
+                                    grep --only-matching '"level":.' | \
+                                    cut -d : -f 2  )
+  assertEquals "Command should have succeeded" 0 "$?"
+
+  assertEquals "Should be UL 2" 2 "$correctUL"
+
+  # upload borked update level to backend
+  sleep 5
+
+  echo "UPLOAD BORKED UL, FFS"
+  upload_update_level "./tests/rollback/2-ingest-borked.json"
+
+  # wait enough until upgrade happens, then rollback: check UL is the same as before
+  wait_for_jenkins
+
+  # FIXME: fixed sleep time is crappy
+  sleep 120
+  assertEquals "Should be UL 2" 2 "$correctUL"
+
+  # let's now check the upload and upgrade attempt to borked UL3 *actually* happened
+  # because if this didn't, then we'd still on UL2, but not testing there was a rollback somewhere
+  beforeLastUpdate=$( docker exec "$container_under_test" bash -c 'cat $EVERGREEN_DATA/updates.auditlog' | tail -2 | head -1 | jq -r .updateLevel )
+  lastUpdate=$( docker exec "$container_under_test" bash -c 'cat $EVERGREEN_DATA/updates.auditlog' | tail -1 | jq -r .updateLevel )
+
+  assertEquals "Previous UL should be 3, the one expected to be rolled back" 3 "$beforeLastUpdate"
+  assertEquals "UL should be 2 (gone back to 2 from borked 3)" 2 "$lastUpdate"
+
+}
+
+. ./shunit2/shunit2

--- a/distribution/tests/rollback-tests.sh
+++ b/distribution/tests/rollback-tests.sh
@@ -46,7 +46,7 @@ test_rollback() {
   wait_for_jenkins
 
   # FIXME: fixed sleep time is crappy
-  sleep 300
+  sleep 600
   assertEquals "Should be UL 2" 2 "$correctUL"
 
   # let's now check the upload and upgrade attempt to borked UL3 *actually* happened

--- a/distribution/tests/rollback-tests.sh
+++ b/distribution/tests/rollback-tests.sh
@@ -33,6 +33,11 @@ test_rollback() {
   assertEquals "Command should have succeeded" 0 "$?"
   assertEquals "Should be UL 2" 2 "$correctUL"
 
+  # FIXME: un-harcode the sleep below. We need to wait for the full startup from above, healthcheck included.
+  # what can happen here is that we'll reach the upload_update_level call below *before* the healthcheck finished
+  # which will make the new pushed update for UL3 to be ignored because an "update is already running" when calling Update.applyUpdates()
+  sleep 10
+
   # upload borked update level to backend
   echo "UPLOADING BROKEN UPDATE LEVEL (MISSING CREDENTIALS PLUGIN)"
   upload_update_level "./tests/rollback/2-ingest-borked.json"

--- a/distribution/tests/rollback-tests.sh
+++ b/distribution/tests/rollback-tests.sh
@@ -37,17 +37,13 @@ test_rollback() {
   assertEquals "Should be UL 2" 2 "$correctUL"
 
   # upload borked update level to backend
-  sleep 10
-
-  echo "UPLOAD BORKED UL, FFS"
+  echo "UPLOADING BROKEN UPDATE LEVEL (MISSING CREDENTIALS PLUGIN)"
   upload_update_level "./tests/rollback/2-ingest-borked.json"
 
   # wait enough until upgrade happens, then rollback: check UL is the same as before
-  wait_for_jenkins
-
-  # FIXME: fixed sleep time is crappy
-  sleep 600
-  assertEquals "Should be UL 2" 2 "$correctUL"
+  now=$( date --iso-8601=seconds )
+  echo "Waiting for Jenkins to restart a first time to broken UL3, then back to UL2 (using logs --since=$now)"
+  wait_for_jenkins "$now"
 
   # let's now check the upload and upgrade attempt to borked UL3 *actually* happened
   # because if this didn't, then we'd still on UL2, but not testing there was a rollback somewhere

--- a/distribution/tests/rollback-tests.sh
+++ b/distribution/tests/rollback-tests.sh
@@ -37,7 +37,7 @@ test_rollback() {
   assertEquals "Should be UL 2" 2 "$correctUL"
 
   # upload borked update level to backend
-  sleep 5
+  sleep 10
 
   echo "UPLOAD BORKED UL, FFS"
   upload_update_level "./tests/rollback/2-ingest-borked.json"

--- a/distribution/tests/rollback-tests.sh
+++ b/distribution/tests/rollback-tests.sh
@@ -7,8 +7,6 @@ export PATH="$current_directory/../../tools:$PATH"
 
 echo "Debugging: PATH=***$PATH***"
 
-JENKINS_HOME=to_override
-
 # shellcheck source=tests/utilities
 . "$current_directory/utilities"
 
@@ -20,20 +18,19 @@ oneTimeSetUp() {
   upload_update_level "./tests/rollback/1-ingest-ok.json"
 
   wait_for_jenkins
-  # shellcheck disable=SC2016
-  JENKINS_HOME="$( docker exec "$container_under_test" bash -c 'echo $JENKINS_HOME' )"
 }
 
 test_rollback() {
 
   # Check UL is the correct one (UL 1 or UL 2?!)
+  # shellcheck disable=SC2016
   docker exec "$container_under_test" bash -c 'ls $EVERGREEN_DATA'
   # extract 2 from `"level":2` from the updates.json file
+  # shellcheck disable=SC2016
   correctUL=$( docker exec "$container_under_test" bash -c 'cat $EVERGREEN_DATA/updates.json' | \
                                     grep --only-matching '"level":.' | \
                                     cut -d : -f 2  )
   assertEquals "Command should have succeeded" 0 "$?"
-
   assertEquals "Should be UL 2" 2 "$correctUL"
 
   # upload borked update level to backend
@@ -47,7 +44,9 @@ test_rollback() {
 
   # let's now check the upload and upgrade attempt to borked UL3 *actually* happened
   # because if this didn't, then we'd still on UL2, but not testing there was a rollback somewhere
+  # shellcheck disable=SC2016
   beforeLastUpdate=$( docker exec "$container_under_test" bash -c 'cat $EVERGREEN_DATA/updates.auditlog' | tail -2 | head -1 | jq -r .updateLevel )
+  # shellcheck disable=SC2016
   lastUpdate=$( docker exec "$container_under_test" bash -c 'cat $EVERGREEN_DATA/updates.auditlog' | tail -1 | jq -r .updateLevel )
 
   assertEquals "Previous UL should be 3, the one expected to be rolled back" 3 "$beforeLastUpdate"

--- a/distribution/tests/rollback-tests.sh
+++ b/distribution/tests/rollback-tests.sh
@@ -46,7 +46,7 @@ test_rollback() {
   wait_for_jenkins
 
   # FIXME: fixed sleep time is crappy
-  sleep 120
+  sleep 300
   assertEquals "Should be UL 2" 2 "$correctUL"
 
   # let's now check the upload and upgrade attempt to borked UL3 *actually* happened

--- a/distribution/tests/rollback/1-ingest-ok.json
+++ b/distribution/tests/rollback/1-ingest-ok.json
@@ -1,0 +1,1062 @@
+{
+  "timestamp": 1538514230894,
+  "core": {
+    "url": "http://mirrors.jenkins.io/war/2.143/jenkins.war",
+    "checksum": {
+      "type": "sha256",
+      "signature": "0e596dcff028f635a03fd0065940d6d02d902b984cf4042bd79e2df394db683b"
+    }
+  },
+  "plugins": [
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "ace-editor",
+      "version": "1.0.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/ace-editor/1.0.1/ace-editor-1.0.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d961d2906a777cdb28cd1c76a0621a08159e44f6618b785d430d04007412be58"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "apache-httpcomponents-client-4-api",
+      "version": "4.5.5-3.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/apache-httpcomponents-client-4-api/4.5.5-3.0/apache-httpcomponents-client-4-api-4.5.5-3.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "5a70481070d87aa977159450038c54f77ad3e11e8c97e3e915c4e0ac668bdde7"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "authentication-tokens",
+      "version": "1.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/authentication-tokens/1.3/authentication-tokens-1.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f05736bc7da0df3bba5ceb4d893089706812ced3134adb2edc9ae341467f1ae3"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean/1.8.4/blueocean-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "132c364f67b5b1e315cc1c5826f2b7889f63c84feef82e645ee90043496a455c"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "blueocean-autofavorite",
+      "version": "1.2.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/blueocean-autofavorite/1.2.2/blueocean-autofavorite-1.2.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "fb0daef66308b1c3ab03ba07bb70ce03d880f46e79650f7f32d8f657d4585700"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-bitbucket-pipeline",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-bitbucket-pipeline/1.8.4/blueocean-bitbucket-pipeline-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "dcc34adef9766a3951e3d9b80cea0970bcffce95c1505ff24ee226970245a5dd"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-commons",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-commons/1.8.4/blueocean-commons-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "27d57ea550c78574067aa16f64e7c8e3f1ab4f6cf3ba1158385346298045a379"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-config",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-config/1.8.4/blueocean-config-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b7cecbf891a1c5a00cf91af0449fcafacd07e0d5d72e8674608c63ff7527b98d"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-core-js",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-core-js/1.8.4/blueocean-core-js-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1e55a18de56db685eeee317b3512c569354f8e386849e87ecdc8bcc14389b942"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-dashboard",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-dashboard/1.8.4/blueocean-dashboard-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "eb443bbec69eb517f677ce68c6c993c958e1363c73e771539278a8563514f962"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "blueocean-display-url",
+      "version": "2.2.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/blueocean-display-url/2.2.0/blueocean-display-url-2.2.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4392cff3f4d75c678abadb7aad040b782be7ea61c5c87bdd5e3a62fa633e10ca"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-events",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-events/1.8.4/blueocean-events-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "aa04b78628b68f8930e720a12be942883ef19f8f6114b008b0aef366ba503dc4"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-git-pipeline",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-git-pipeline/1.8.4/blueocean-git-pipeline-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "7a1d79df09bd682f9263ec80d53a6cf478aeb2c3942e52ccf1efbc9e1bddbc3b"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-github-pipeline",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-github-pipeline/1.8.4/blueocean-github-pipeline-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "2e35872a28069da183fac24d9896497114857b7c365394ba605bf7b919000b20"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-i18n",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-i18n/1.8.4/blueocean-i18n-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f6f66c723916da411d4aea7200a7bfcd2a90b1ebf897b08c9aee7976d452870c"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-jira",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-jira/1.8.4/blueocean-jira-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8aa7d3c0a774ac82bbec332186f3ec911abcd0e0b6b83fca465e7fa1bf889a08"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-jwt",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-jwt/1.8.4/blueocean-jwt-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "ea49120584de4c02abda423e33672a650d5e41175d58eb24c123aa460867d6dc"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-personalization",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-personalization/1.8.4/blueocean-personalization-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1a06ae8519f5e92890d645538a80f7c888d7c1e76bb0cb5a6a7b7b245637d508"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-pipeline-api-impl",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-pipeline-api-impl/1.8.4/blueocean-pipeline-api-impl-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "06e311c27de19156917152ee3a57f75a1a89f34599265259ed99a79721aec802"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-pipeline-editor",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-pipeline-editor/1.8.4/blueocean-pipeline-editor-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f30e4c6d9b60e5df908db6d19260e6f68cc56ebbda426ad688ab5dfa570f2407"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-pipeline-scm-api",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-pipeline-scm-api/1.8.4/blueocean-pipeline-scm-api-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "c64bf7968ef7e95b0316790203ddefbc9524e5b41596a8928add6870ee9a5516"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-rest",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-rest/1.8.4/blueocean-rest-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "eedee5b8146f04b785db6835dbb45fbe1e7de5d2198a6ddf18a54e11222bbf53"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-rest-impl",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-rest-impl/1.8.4/blueocean-rest-impl-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "cfbba63c1857d62fd07f6be68c742cbd59fcbf5adc6226d9874b73be4a081c12"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-web",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-web/1.8.4/blueocean-web-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b98e78916bc86bb2ed7e0b0a8b109c3fe4a781be791953c3eade935299042db2"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "bouncycastle-api",
+      "version": "2.17",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/bouncycastle-api/2.17/bouncycastle-api-2.17.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "bf71f88eda34bd304ded9ac374bbcdaeb0dccb8618dd94bdfa2af486d7971f21"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "branch-api",
+      "version": "2.0.20",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/branch-api/2.0.20/branch-api-2.0.20.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "7c8d4890b51257d7a52da2307e98a4dbb11ef64fb353e3c0c4cb7f4579bc5e9e"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "buildtriggerbadge",
+      "version": "2.9",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/buildtriggerbadge/2.9/buildtriggerbadge-2.9.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d7624bbfeae442c467ef9faeaa6f29e11d5f3b23774e500af7ccddbb9d34fc36"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "cloudbees-bitbucket-branch-source",
+      "version": "2.2.9",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/cloudbees-bitbucket-branch-source/2.2.9/cloudbees-bitbucket-branch-source-2.2.9.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "74687f0c9b51a9a9ae4b26958e44d9011a4dd9a3c7cec7013187c5dd9ef0337c"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "cloudbees-folder",
+      "version": "6.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/cloudbees-folder/6.3/cloudbees-folder-6.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4f21d3dedd352fe1fb0c6adea1d39dcb190180615e5cc5aa5ffac18b47c5a71a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "config-file-provider",
+      "version": "3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/config-file-provider/3.2/config-file-provider-3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "495ffb2310c5e31c5021bfb3493e027ecbb16c4042ccc5707d983d884b96939f"
+      }
+    },
+    {
+      "groupId": "io.jenkins",
+      "artifactId": "configuration-as-code",
+      "version": "1.0",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/configuration-as-code/1.0/configuration-as-code-1.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "23cbe0e0557d27a1b0510ba80a146b6f821d6174222e5f0e29bdd6fb54e18e30"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "credentials",
+      "version": "2.1.17",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/credentials/2.1.17/credentials-2.1.17.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "59cc39c082428602b6b7439f7f76af86d5347b02e335df3f263b1eef93f8b1d5"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "credentials-binding",
+      "version": "1.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/credentials-binding/1.16/credentials-binding-1.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "14ba179ac02923b78218340b55b8c6203e1664c5e407f4021a986653ba9564e2"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "display-url-api",
+      "version": "2.2.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/display-url-api/2.2.0/display-url-api-2.2.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f9a7acb09a0c649d2cfe25ed52d6a974e664f3a00e76d9dccf24f845d20bb754"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "docker-commons",
+      "version": "1.13",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/docker-commons/1.13/docker-commons-1.13.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "33039e977d93adf6f57a8938d2b9d3725464f7dedcf248feb754434d4fa0104a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "docker-workflow",
+      "version": "1.14",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/docker-workflow/1.14/docker-workflow-1.14.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "cb2304a61477f06d619df39464f0dd952074b5ac1954b993126302abc2b97457"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "durable-task",
+      "version": "1.24",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/durable-task/1.24/durable-task-1.24.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "46f55162ffe2a4bcea35d6adbf4e595e9e9e5f6c7268766e2e995bba203ce96f"
+      }
+    },
+    {
+      "groupId": "io.jenkins.plugins",
+      "artifactId": "essentials",
+      "version": "0.5.1",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/plugins/essentials/0.5.1/essentials-0.5.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "63610d131fad3eb6f3cca6b7f21d55833aa7990b82bf087afc6071af9f5d31f3"
+      }
+    },
+    {
+      "groupId": "io.jenkins.plugins",
+      "artifactId": "evergreen",
+      "version": "1.0-rc58.a9ecd200b39a",
+      "url": "https://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen/1.0-rc58.a9ecd200b39a/evergreen-1.0-rc58.a9ecd200b39a.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d5fd13e57eb2cfb030bef235206f1b7c97fec5d158c2e8a0106cf8a6b0617de7"
+      }
+    },
+    {
+      "groupId": "org.jvnet.hudson.plugins",
+      "artifactId": "favorite",
+      "version": "2.3.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jvnet/hudson/plugins/favorite/2.3.1/favorite-2.3.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b847647271830a3cec63035dea8fffe79b91331678cd306967cbc64227d4db28"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "git",
+      "version": "4.0.0-rc2892.70634f157021",
+      "url": "https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/git/4.0.0-rc2892.70634f157021/git-4.0.0-rc2892.70634f157021.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f0def98957cd14d69e8fc3e6debed91311f784ab7c91c79323fbca0d8e80de84"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "git-client",
+      "version": "3.0.0-beta6-rc1776.912790760394",
+      "url": "https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/git-client/3.0.0-beta6-rc1776.912790760394/git-client-3.0.0-beta6-rc1776.912790760394.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "352f6608d97be2ed0fbddd1778c0dc9b094a5cc623a0abb28247fb894ca41f6b"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "git-server",
+      "version": "1.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/git-server/1.7/git-server-1.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1a5dc733495681a6d1a6adce07e614e50f4e5d22580e6fafbd5ca260aa4367fc"
+      }
+    },
+    {
+      "groupId": "com.coravy.hudson.plugins.github",
+      "artifactId": "github",
+      "version": "1.29.2",
+      "url": "https://repo.jenkins-ci.org/releases/com/coravy/hudson/plugins/github/github/1.29.2/github-1.29.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "3f4b3f310c405f34cd672c59d8dc6e453c7881380fcb4cb2c1994a6e0e73e121"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "github-api",
+      "version": "1.90",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/github-api/1.90/github-api-1.90.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8ec10c98b4cc103d826e2e2a101b4bf44b3b91b395c33de7448003431ba736ce"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "github-branch-source",
+      "version": "2.3.6",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/github-branch-source/2.3.6/github-branch-source-2.3.6.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "84a69dcf981dd253b6f8d4fe79178a3eb58f44cae24a35246488d9ca8f2b118f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "handlebars",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/handlebars/1.1/handlebars-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "0caf2bff158f7b6d8939d599779b2a20180cb1394c0e2fe3f10c43c562f2a3e4"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "handy-uri-templates-2-api",
+      "version": "2.1.6-1.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/handy-uri-templates-2-api/2.1.6-1.0/handy-uri-templates-2-api-2.1.6-1.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "09446d387f5e87a846469334579292f3047b3d4cabf3dd05cd057a2f34b39814"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "htmlpublisher",
+      "version": "1.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/htmlpublisher/1.16/htmlpublisher-1.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4a8153f9791e08cd07d0bcc3ee57d97e21f38c15d578311f6e805c650029a5c5"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.icon-shim",
+      "artifactId": "icon-shim",
+      "version": "2.0.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/icon-shim/icon-shim/2.0.3/icon-shim-2.0.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8ab2f1617b68561a7f0254fb27578840aa9b7e158d0bd8c51628dbc64e8ab0ca"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jackson2-api",
+      "version": "2.8.11.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jackson2-api/2.8.11.2/jackson2-api-2.8.11.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "163e005e9335fb7b00afb00d3b0530b034f3612abd1639d1b17ec1e8f5a88902"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jdk-tool",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jdk-tool/1.1/jdk-tool-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "87ffa354eb3c3eba1185d6086abdd32d60e22fabdd98dfb52cbeba7b1a1a3d4c"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "jenkins-design-language",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/jenkins-design-language/1.8.4/jenkins-design-language-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b3595453a4acb3b33ffef9dee64dfa80c2cb8c4195ad6cd5f71f3cf6a62b11d0"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jira",
+      "version": "3.0.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jira/3.0.2/jira-3.0.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "536f6d68d0832b7641f66d5e7d529961cec111b489fd0e9130a763ead767385f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "jquery-detached",
+      "version": "1.2.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/jquery-detached/1.2.1/jquery-detached-1.2.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "a05273cd20c11557ffcb7dcb75150f21d35dc8be28355548b831c2960d7f11c0"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jsch",
+      "version": "0.1.54.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jsch/0.1.54.2/jsch-0.1.54.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f2988fb4d8fdf1dff395b4cda966a5d542eb25afa5469c144aeb9031f4b28e2f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "junit",
+      "version": "1.26.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/junit/1.26.1/junit-1.26.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "55d03fb3cdbb21c32d52b9b938ed3e807e7caccc2b49c507bc417d75e3e8b364"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "mailer",
+      "version": "1.21",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/mailer/1.21/mailer-1.21.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "23acf5c90910ed803d2bac4b33eebda94097d26595c8fc8fe09ac6d29750a0ba"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "matrix-project",
+      "version": "1.12",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/matrix-project/1.12/matrix-project-1.12.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "bc3300877704d41d42813d6cef18ea017dcb4be5e8faae45a7da4ce6c9b540e1"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "mercurial",
+      "version": "2.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/mercurial/2.4/mercurial-2.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "a45f67b963329eae13eb454e2d5b3f9859af76decaf1ebdeaa4338fb6a820ef8"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "metrics",
+      "version": "4.0.2.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/metrics/4.0.2.2/metrics-4.0.2.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b60b49ab946cd8b960f999876b7da880fadf9ca07dd9524f9f0af63a5d0342eb"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "momentjs",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/momentjs/1.1/momentjs-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "82fc097fdea9c2387d52f9be55cbd80d36d0b644e66e9ffb4c09f6f216a22333"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-build-step",
+      "version": "2.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-build-step/2.7/pipeline-build-step-2.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d02fd27988328435c0bc4211e4e45fee88b28b5d633c3bbce6cb4dca9480a9cb"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-graph-analysis",
+      "version": "1.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-graph-analysis/1.7/pipeline-graph-analysis-1.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "9934e518f55c0bc8be27775622b0f3bebef354550b19931ffa45dfb51a4e381c"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-input-step",
+      "version": "2.8",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-input-step/2.8/pipeline-input-step-2.8.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8e9fa1654ec0c0ec726c894b079828737b8ce6d9ea3d05cd4378c37acc3235db"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-milestone-step",
+      "version": "1.3.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-milestone-step/1.3.1/pipeline-milestone-step-1.3.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d3a26629b656821c60a14fe403ab8afc50f084e338406dbc27e2b6b403f7cb20"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-api",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-api/1.3.2/pipeline-model-api-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "7cf8a34e6c37805e0353a3b85e21c24479bf72d2bc82e9d72dd6777f2358deba"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-declarative-agent",
+      "version": "1.1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-declarative-agent/1.1.1/pipeline-model-declarative-agent-1.1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d5540c3973bf5f568910f93b3a002c413148b9d3dd4211ce5faf4a2a1214d4ef"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-definition",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-definition/1.3.2/pipeline-model-definition-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b4f237c550520fcec43f7d4733de200eef386ef1492e0f43df74a15388d024e7"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-extensions",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-extensions/1.3.2/pipeline-model-extensions-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d5669f3a98f42526c3abc78813cbdd856c25bc76ab2b9cf360b8fde15bf53053"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.pipeline-stage-view",
+      "artifactId": "pipeline-rest-api",
+      "version": "2.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-stage-view/pipeline-rest-api/2.4/pipeline-rest-api-2.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "20358e42da2f7a568867b612fb95af97a5abfb2de6241171792b66d29b42cdbb"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-stage-step",
+      "version": "2.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-stage-step/2.3/pipeline-stage-step-2.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f6caab90742664289b0cb57b27755c3b8b963c3764894129fb954efbf796d310"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-stage-tags-metadata",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-stage-tags-metadata/1.3.2/pipeline-stage-tags-metadata-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1d02c829b497c34ac0f40435f5fdb4421319ed8a3ef11a89070bde329bb6d973"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.pipeline-stage-view",
+      "artifactId": "pipeline-stage-view",
+      "version": "2.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-stage-view/pipeline-stage-view/2.4/pipeline-stage-view-2.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1565fd1f2eceab366dfb22db083dfa45fb0c1f16321fdcb19deac47f8a5ff3be"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "plain-credentials",
+      "version": "1.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/plain-credentials/1.4/plain-credentials-1.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4f1834f99ffd7f2a7db1972fe46ee42d06af819b27297193ac89eb33a14292d8"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pubsub-light",
+      "version": "1.12",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pubsub-light/1.12/pubsub-light-1.12.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "666cbc579d82849bef8d0396a57335c9994222e8b0ba52f07be76dab9fb56c40"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "scm-api",
+      "version": "2.2.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/scm-api/2.2.7/scm-api-2.2.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "9c550f85ad8570b9d777a3c9880188fb00e84cbdf5b3704977e1a3e3edc73a47"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "script-security",
+      "version": "1.46",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/script-security/1.46/script-security-1.46.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8b7fd476309e61402cd95657a51869b906c39f696adac02779222007b89fa969"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "sse-gateway",
+      "version": "1.15",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/sse-gateway/1.15/sse-gateway-1.15.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "56b19b7a48f646dc8269bae4aca41ec11f71756d618d302b1f8b9d688441850f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "ssh-agent",
+      "version": "1.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ssh-agent/1.16/ssh-agent-1.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "18bab0fdcf65cec220866abd5ca8df9541b1091e1a876d9acb3283c6a969c478"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "ssh-credentials",
+      "version": "1.14",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ssh-credentials/1.14/ssh-credentials-1.14.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f5fc11e306cd0fe0abb25ffcf40014d6bc3c31318e9d2d3309e965320dfdde34"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "structs",
+      "version": "1.14",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/structs/1.14/structs-1.14.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "43a27488fd58f95affdef0766570bbe705ac8c39fe11d3b38208282c21cac58b"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "token-macro",
+      "version": "2.5",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/token-macro/2.5/token-macro-2.5.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "c6575d030ef6e0b416dad38094355eed30e860ade38759ff0a76e2f588350e6b"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "variant",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/variant/1.1/variant-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "971893fb05da213631b8ea977a32a5d4953f1cb7ab6fbdec9020d503550275ff"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-aggregator",
+      "version": "2.5",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-aggregator/2.5/workflow-aggregator-2.5.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f5122377769a5e43ee4c2d88c720dd893054c3658fc4d29f21d362eabcaac86a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-api",
+      "version": "2.29",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-api/2.29/workflow-api-2.29.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f4cc9ea93ff77f51e16173f1e0c3e3646e92f1467bbc47f08b4574b380a93b32"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-basic-steps",
+      "version": "2.6",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-basic-steps/2.6/workflow-basic-steps-2.6.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "ba6bc7f586b902ba6aacae571a8ae78916e7f3e106d8a7da14c348ea933f0016"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-cps",
+      "version": "2.54",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-cps/2.54/workflow-cps-2.54.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8d23332a54d8a744bd15a47d2eecd022068b2d40b62bc51b6c8b4dfdaf48894e"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-cps-global-lib",
+      "version": "2.9",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-cps-global-lib/2.9/workflow-cps-global-lib-2.9.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b5a141c4896be15e09d76fc5b60df3fe701e94d2c2d2015a99ca5147a78b09d1"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-durable-task-step",
+      "version": "2.21",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-durable-task-step/2.21/workflow-durable-task-step-2.21.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "ff94f25addaf21bf510b6553572045f701daf94537a0763e47fb0f8446d24d2f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-job",
+      "version": "2.25",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-job/2.25/workflow-job-2.25.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "0c8500f819f34e008d90292a691b4fb4638a911a7fa5f31a3cb7a427a97f3c9d"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-multibranch",
+      "version": "2.20",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-multibranch/2.20/workflow-multibranch-2.20.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "c32aee40afd0684fd64dc4b13ea292667e26a33552c29fe8a02f72d57c6d1e1a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-scm-step",
+      "version": "2.6",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-scm-step/2.6/workflow-scm-step-2.6.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "a382864adaf0fc80d58243568157a1450028e6d0503a03b81111d4c4de8275d0"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-step-api",
+      "version": "2.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-step-api/2.16/workflow-step-api-2.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d642a4099d49be3cac71270e52565a367348c7ed45cde4d9e32ed0624c78759f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-support",
+      "version": "2.20",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-support/2.20/workflow-support-2.20.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "72add03ae7bc3d66d5cc46b425c13891ef5ce7a3fee839de1ceded2d3978086f"
+      }
+    }
+  ],
+  "environments": {
+    "docker-cloud": {
+      "plugins": [
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "docker-java-api",
+          "version": "3.0.14",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/docker-java-api/3.0.14/docker-java-api-3.0.14.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "14a48f9092863c7680c939c3163d9539e3b66f8e277fbe4c0e26a68cc60c4ba0"
+          }
+        },
+        {
+          "groupId": "io.jenkins.docker",
+          "artifactId": "docker-plugin",
+          "version": "1.1.6-rc865.abf142391212",
+          "url": "https://repo.jenkins-ci.org/incrementals/io/jenkins/docker/docker-plugin/1.1.6-rc865.abf142391212/docker-plugin-1.1.6-rc865.abf142391212.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "0d4e1f98dded7d9850603c2d7f9951886816ab7f569bd2ca5a97af7cd7ae812e"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "ssh-slaves",
+          "version": "1.22",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ssh-slaves/1.22/ssh-slaves-1.22.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "4a8f37338cf1740fcff0fbd7474d7f9532e954ccc276eb89f11cf91c2ac273e1"
+          }
+        }
+      ]
+    },
+    "aws-ec2-cloud": {
+      "plugins": [
+        {
+          "groupId": "io.jenkins.plugins",
+          "artifactId": "artifact-manager-s3",
+          "version": "1.1",
+          "url": "https://repo.jenkins-ci.org/releases/io/jenkins/plugins/artifact-manager-s3/1.1/artifact-manager-s3-1.1.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "c3c3467272febe6f7c6954cc76a36f96df6c73f0aa49a4ce5e478baac1d5bf25"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "aws-credentials",
+          "version": "1.23",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/aws-credentials/1.23/aws-credentials-1.23.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "20fe4b5c1273aee66b28adb504ccd0fbb0b44e240b84bdc74ef7a38749ee726e"
+          }
+        },
+        {
+          "groupId": "io.jenkins.plugins",
+          "artifactId": "aws-global-configuration",
+          "version": "1.0",
+          "url": "https://repo.jenkins-ci.org/releases/io/jenkins/plugins/aws-global-configuration/1.0/aws-global-configuration-1.0.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "ec03800c870e40de92a42c5e397e5988ddf564e8fd499d77d0eec6d2c575a4f9"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "aws-java-sdk",
+          "version": "1.11.341",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/aws-java-sdk/1.11.341/aws-java-sdk-1.11.341.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "ebe7cca7755dc020d138ef537a7bf7b61e3bbad41f7f0f6be4004917c0769238"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "ec2",
+          "version": "1.39",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ec2/1.39/ec2-1.39.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "fdd8670b1a71bcdacc5d7a358fa67fb8c44efc6f2ecc717d5e572c669934a0a7"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "node-iterator-api",
+          "version": "1.5",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/node-iterator-api/1.5/node-iterator-api-1.5.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "ea5a5294fcccad5a26a7004edcb1e256bc2976fa68993ac17570370337f4d34a"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/distribution/tests/rollback/2-ingest-borked.json
+++ b/distribution/tests/rollback/2-ingest-borked.json
@@ -1,0 +1,1052 @@
+{
+  "timestamp": 1538514230894,
+  "core": {
+    "url": "http://mirrors.jenkins.io/war/2.143/jenkins.war",
+    "checksum": {
+      "type": "sha256",
+      "signature": "0e596dcff028f635a03fd0065940d6d02d902b984cf4042bd79e2df394db683b"
+    }
+  },
+  "plugins": [
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "ace-editor",
+      "version": "1.0.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/ace-editor/1.0.1/ace-editor-1.0.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d961d2906a777cdb28cd1c76a0621a08159e44f6618b785d430d04007412be58"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "apache-httpcomponents-client-4-api",
+      "version": "4.5.5-3.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/apache-httpcomponents-client-4-api/4.5.5-3.0/apache-httpcomponents-client-4-api-4.5.5-3.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "5a70481070d87aa977159450038c54f77ad3e11e8c97e3e915c4e0ac668bdde7"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "authentication-tokens",
+      "version": "1.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/authentication-tokens/1.3/authentication-tokens-1.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f05736bc7da0df3bba5ceb4d893089706812ced3134adb2edc9ae341467f1ae3"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean/1.8.4/blueocean-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "132c364f67b5b1e315cc1c5826f2b7889f63c84feef82e645ee90043496a455c"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "blueocean-autofavorite",
+      "version": "1.2.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/blueocean-autofavorite/1.2.2/blueocean-autofavorite-1.2.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "fb0daef66308b1c3ab03ba07bb70ce03d880f46e79650f7f32d8f657d4585700"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-bitbucket-pipeline",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-bitbucket-pipeline/1.8.4/blueocean-bitbucket-pipeline-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "dcc34adef9766a3951e3d9b80cea0970bcffce95c1505ff24ee226970245a5dd"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-commons",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-commons/1.8.4/blueocean-commons-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "27d57ea550c78574067aa16f64e7c8e3f1ab4f6cf3ba1158385346298045a379"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-config",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-config/1.8.4/blueocean-config-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b7cecbf891a1c5a00cf91af0449fcafacd07e0d5d72e8674608c63ff7527b98d"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-core-js",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-core-js/1.8.4/blueocean-core-js-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1e55a18de56db685eeee317b3512c569354f8e386849e87ecdc8bcc14389b942"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-dashboard",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-dashboard/1.8.4/blueocean-dashboard-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "eb443bbec69eb517f677ce68c6c993c958e1363c73e771539278a8563514f962"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "blueocean-display-url",
+      "version": "2.2.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/blueocean-display-url/2.2.0/blueocean-display-url-2.2.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4392cff3f4d75c678abadb7aad040b782be7ea61c5c87bdd5e3a62fa633e10ca"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-events",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-events/1.8.4/blueocean-events-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "aa04b78628b68f8930e720a12be942883ef19f8f6114b008b0aef366ba503dc4"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-git-pipeline",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-git-pipeline/1.8.4/blueocean-git-pipeline-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "7a1d79df09bd682f9263ec80d53a6cf478aeb2c3942e52ccf1efbc9e1bddbc3b"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-github-pipeline",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-github-pipeline/1.8.4/blueocean-github-pipeline-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "2e35872a28069da183fac24d9896497114857b7c365394ba605bf7b919000b20"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-i18n",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-i18n/1.8.4/blueocean-i18n-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f6f66c723916da411d4aea7200a7bfcd2a90b1ebf897b08c9aee7976d452870c"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-jira",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-jira/1.8.4/blueocean-jira-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8aa7d3c0a774ac82bbec332186f3ec911abcd0e0b6b83fca465e7fa1bf889a08"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-jwt",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-jwt/1.8.4/blueocean-jwt-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "ea49120584de4c02abda423e33672a650d5e41175d58eb24c123aa460867d6dc"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-personalization",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-personalization/1.8.4/blueocean-personalization-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1a06ae8519f5e92890d645538a80f7c888d7c1e76bb0cb5a6a7b7b245637d508"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-pipeline-api-impl",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-pipeline-api-impl/1.8.4/blueocean-pipeline-api-impl-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "06e311c27de19156917152ee3a57f75a1a89f34599265259ed99a79721aec802"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-pipeline-editor",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-pipeline-editor/1.8.4/blueocean-pipeline-editor-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f30e4c6d9b60e5df908db6d19260e6f68cc56ebbda426ad688ab5dfa570f2407"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-pipeline-scm-api",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-pipeline-scm-api/1.8.4/blueocean-pipeline-scm-api-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "c64bf7968ef7e95b0316790203ddefbc9524e5b41596a8928add6870ee9a5516"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-rest",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-rest/1.8.4/blueocean-rest-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "eedee5b8146f04b785db6835dbb45fbe1e7de5d2198a6ddf18a54e11222bbf53"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-rest-impl",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-rest-impl/1.8.4/blueocean-rest-impl-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "cfbba63c1857d62fd07f6be68c742cbd59fcbf5adc6226d9874b73be4a081c12"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "blueocean-web",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/blueocean-web/1.8.4/blueocean-web-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b98e78916bc86bb2ed7e0b0a8b109c3fe4a781be791953c3eade935299042db2"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "bouncycastle-api",
+      "version": "2.17",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/bouncycastle-api/2.17/bouncycastle-api-2.17.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "bf71f88eda34bd304ded9ac374bbcdaeb0dccb8618dd94bdfa2af486d7971f21"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "branch-api",
+      "version": "2.0.20",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/branch-api/2.0.20/branch-api-2.0.20.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "7c8d4890b51257d7a52da2307e98a4dbb11ef64fb353e3c0c4cb7f4579bc5e9e"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "buildtriggerbadge",
+      "version": "2.9",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/buildtriggerbadge/2.9/buildtriggerbadge-2.9.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d7624bbfeae442c467ef9faeaa6f29e11d5f3b23774e500af7ccddbb9d34fc36"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "cloudbees-bitbucket-branch-source",
+      "version": "2.2.9",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/cloudbees-bitbucket-branch-source/2.2.9/cloudbees-bitbucket-branch-source-2.2.9.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "74687f0c9b51a9a9ae4b26958e44d9011a4dd9a3c7cec7013187c5dd9ef0337c"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "cloudbees-folder",
+      "version": "6.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/cloudbees-folder/6.3/cloudbees-folder-6.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4f21d3dedd352fe1fb0c6adea1d39dcb190180615e5cc5aa5ffac18b47c5a71a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "config-file-provider",
+      "version": "3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/config-file-provider/3.2/config-file-provider-3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "495ffb2310c5e31c5021bfb3493e027ecbb16c4042ccc5707d983d884b96939f"
+      }
+    },
+    {
+      "groupId": "io.jenkins",
+      "artifactId": "configuration-as-code",
+      "version": "1.0",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/configuration-as-code/1.0/configuration-as-code-1.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "23cbe0e0557d27a1b0510ba80a146b6f821d6174222e5f0e29bdd6fb54e18e30"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "credentials-binding",
+      "version": "1.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/credentials-binding/1.16/credentials-binding-1.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "14ba179ac02923b78218340b55b8c6203e1664c5e407f4021a986653ba9564e2"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "display-url-api",
+      "version": "2.2.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/display-url-api/2.2.0/display-url-api-2.2.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f9a7acb09a0c649d2cfe25ed52d6a974e664f3a00e76d9dccf24f845d20bb754"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "docker-commons",
+      "version": "1.13",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/docker-commons/1.13/docker-commons-1.13.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "33039e977d93adf6f57a8938d2b9d3725464f7dedcf248feb754434d4fa0104a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "docker-workflow",
+      "version": "1.14",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/docker-workflow/1.14/docker-workflow-1.14.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "cb2304a61477f06d619df39464f0dd952074b5ac1954b993126302abc2b97457"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "durable-task",
+      "version": "1.24",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/durable-task/1.24/durable-task-1.24.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "46f55162ffe2a4bcea35d6adbf4e595e9e9e5f6c7268766e2e995bba203ce96f"
+      }
+    },
+    {
+      "groupId": "io.jenkins.plugins",
+      "artifactId": "essentials",
+      "version": "0.5.1",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/plugins/essentials/0.5.1/essentials-0.5.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "63610d131fad3eb6f3cca6b7f21d55833aa7990b82bf087afc6071af9f5d31f3"
+      }
+    },
+    {
+      "groupId": "io.jenkins.plugins",
+      "artifactId": "evergreen",
+      "version": "1.0-rc58.a9ecd200b39a",
+      "url": "https://repo.jenkins-ci.org/incrementals/io/jenkins/plugins/evergreen/1.0-rc58.a9ecd200b39a/evergreen-1.0-rc58.a9ecd200b39a.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d5fd13e57eb2cfb030bef235206f1b7c97fec5d158c2e8a0106cf8a6b0617de7"
+      }
+    },
+    {
+      "groupId": "org.jvnet.hudson.plugins",
+      "artifactId": "favorite",
+      "version": "2.3.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jvnet/hudson/plugins/favorite/2.3.1/favorite-2.3.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b847647271830a3cec63035dea8fffe79b91331678cd306967cbc64227d4db28"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "git",
+      "version": "4.0.0-rc2892.70634f157021",
+      "url": "https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/git/4.0.0-rc2892.70634f157021/git-4.0.0-rc2892.70634f157021.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f0def98957cd14d69e8fc3e6debed91311f784ab7c91c79323fbca0d8e80de84"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "git-client",
+      "version": "3.0.0-beta6-rc1776.912790760394",
+      "url": "https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/git-client/3.0.0-beta6-rc1776.912790760394/git-client-3.0.0-beta6-rc1776.912790760394.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "352f6608d97be2ed0fbddd1778c0dc9b094a5cc623a0abb28247fb894ca41f6b"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "git-server",
+      "version": "1.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/git-server/1.7/git-server-1.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1a5dc733495681a6d1a6adce07e614e50f4e5d22580e6fafbd5ca260aa4367fc"
+      }
+    },
+    {
+      "groupId": "com.coravy.hudson.plugins.github",
+      "artifactId": "github",
+      "version": "1.29.2",
+      "url": "https://repo.jenkins-ci.org/releases/com/coravy/hudson/plugins/github/github/1.29.2/github-1.29.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "3f4b3f310c405f34cd672c59d8dc6e453c7881380fcb4cb2c1994a6e0e73e121"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "github-api",
+      "version": "1.90",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/github-api/1.90/github-api-1.90.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8ec10c98b4cc103d826e2e2a101b4bf44b3b91b395c33de7448003431ba736ce"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "github-branch-source",
+      "version": "2.3.6",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/github-branch-source/2.3.6/github-branch-source-2.3.6.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "84a69dcf981dd253b6f8d4fe79178a3eb58f44cae24a35246488d9ca8f2b118f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "handlebars",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/handlebars/1.1/handlebars-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "0caf2bff158f7b6d8939d599779b2a20180cb1394c0e2fe3f10c43c562f2a3e4"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "handy-uri-templates-2-api",
+      "version": "2.1.6-1.0",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/handy-uri-templates-2-api/2.1.6-1.0/handy-uri-templates-2-api-2.1.6-1.0.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "09446d387f5e87a846469334579292f3047b3d4cabf3dd05cd057a2f34b39814"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "htmlpublisher",
+      "version": "1.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/htmlpublisher/1.16/htmlpublisher-1.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4a8153f9791e08cd07d0bcc3ee57d97e21f38c15d578311f6e805c650029a5c5"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.icon-shim",
+      "artifactId": "icon-shim",
+      "version": "2.0.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/icon-shim/icon-shim/2.0.3/icon-shim-2.0.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8ab2f1617b68561a7f0254fb27578840aa9b7e158d0bd8c51628dbc64e8ab0ca"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jackson2-api",
+      "version": "2.8.11.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jackson2-api/2.8.11.2/jackson2-api-2.8.11.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "163e005e9335fb7b00afb00d3b0530b034f3612abd1639d1b17ec1e8f5a88902"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jdk-tool",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jdk-tool/1.1/jdk-tool-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "87ffa354eb3c3eba1185d6086abdd32d60e22fabdd98dfb52cbeba7b1a1a3d4c"
+      }
+    },
+    {
+      "groupId": "io.jenkins.blueocean",
+      "artifactId": "jenkins-design-language",
+      "version": "1.8.4",
+      "url": "https://repo.jenkins-ci.org/releases/io/jenkins/blueocean/jenkins-design-language/1.8.4/jenkins-design-language-1.8.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b3595453a4acb3b33ffef9dee64dfa80c2cb8c4195ad6cd5f71f3cf6a62b11d0"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jira",
+      "version": "3.0.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jira/3.0.2/jira-3.0.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "536f6d68d0832b7641f66d5e7d529961cec111b489fd0e9130a763ead767385f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "jquery-detached",
+      "version": "1.2.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/jquery-detached/1.2.1/jquery-detached-1.2.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "a05273cd20c11557ffcb7dcb75150f21d35dc8be28355548b831c2960d7f11c0"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "jsch",
+      "version": "0.1.54.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/jsch/0.1.54.2/jsch-0.1.54.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f2988fb4d8fdf1dff395b4cda966a5d542eb25afa5469c144aeb9031f4b28e2f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "junit",
+      "version": "1.26.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/junit/1.26.1/junit-1.26.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "55d03fb3cdbb21c32d52b9b938ed3e807e7caccc2b49c507bc417d75e3e8b364"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "mailer",
+      "version": "1.21",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/mailer/1.21/mailer-1.21.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "23acf5c90910ed803d2bac4b33eebda94097d26595c8fc8fe09ac6d29750a0ba"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "matrix-project",
+      "version": "1.12",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/matrix-project/1.12/matrix-project-1.12.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "bc3300877704d41d42813d6cef18ea017dcb4be5e8faae45a7da4ce6c9b540e1"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "mercurial",
+      "version": "2.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/mercurial/2.4/mercurial-2.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "a45f67b963329eae13eb454e2d5b3f9859af76decaf1ebdeaa4338fb6a820ef8"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "metrics",
+      "version": "4.0.2.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/metrics/4.0.2.2/metrics-4.0.2.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b60b49ab946cd8b960f999876b7da880fadf9ca07dd9524f9f0af63a5d0342eb"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.ui",
+      "artifactId": "momentjs",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/ui/momentjs/1.1/momentjs-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "82fc097fdea9c2387d52f9be55cbd80d36d0b644e66e9ffb4c09f6f216a22333"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-build-step",
+      "version": "2.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-build-step/2.7/pipeline-build-step-2.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d02fd27988328435c0bc4211e4e45fee88b28b5d633c3bbce6cb4dca9480a9cb"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-graph-analysis",
+      "version": "1.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-graph-analysis/1.7/pipeline-graph-analysis-1.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "9934e518f55c0bc8be27775622b0f3bebef354550b19931ffa45dfb51a4e381c"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-input-step",
+      "version": "2.8",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-input-step/2.8/pipeline-input-step-2.8.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8e9fa1654ec0c0ec726c894b079828737b8ce6d9ea3d05cd4378c37acc3235db"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-milestone-step",
+      "version": "1.3.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-milestone-step/1.3.1/pipeline-milestone-step-1.3.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d3a26629b656821c60a14fe403ab8afc50f084e338406dbc27e2b6b403f7cb20"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-api",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-api/1.3.2/pipeline-model-api-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "7cf8a34e6c37805e0353a3b85e21c24479bf72d2bc82e9d72dd6777f2358deba"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-declarative-agent",
+      "version": "1.1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-declarative-agent/1.1.1/pipeline-model-declarative-agent-1.1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d5540c3973bf5f568910f93b3a002c413148b9d3dd4211ce5faf4a2a1214d4ef"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-definition",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-definition/1.3.2/pipeline-model-definition-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b4f237c550520fcec43f7d4733de200eef386ef1492e0f43df74a15388d024e7"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-model-extensions",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-model-extensions/1.3.2/pipeline-model-extensions-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d5669f3a98f42526c3abc78813cbdd856c25bc76ab2b9cf360b8fde15bf53053"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.pipeline-stage-view",
+      "artifactId": "pipeline-rest-api",
+      "version": "2.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-stage-view/pipeline-rest-api/2.4/pipeline-rest-api-2.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "20358e42da2f7a568867b612fb95af97a5abfb2de6241171792b66d29b42cdbb"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pipeline-stage-step",
+      "version": "2.3",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-stage-step/2.3/pipeline-stage-step-2.3.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f6caab90742664289b0cb57b27755c3b8b963c3764894129fb954efbf796d310"
+      }
+    },
+    {
+      "groupId": "org.jenkinsci.plugins",
+      "artifactId": "pipeline-stage-tags-metadata",
+      "version": "1.3.2",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkinsci/plugins/pipeline-stage-tags-metadata/1.3.2/pipeline-stage-tags-metadata-1.3.2.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1d02c829b497c34ac0f40435f5fdb4421319ed8a3ef11a89070bde329bb6d973"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.pipeline-stage-view",
+      "artifactId": "pipeline-stage-view",
+      "version": "2.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pipeline-stage-view/pipeline-stage-view/2.4/pipeline-stage-view-2.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "1565fd1f2eceab366dfb22db083dfa45fb0c1f16321fdcb19deac47f8a5ff3be"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "plain-credentials",
+      "version": "1.4",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/plain-credentials/1.4/plain-credentials-1.4.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "4f1834f99ffd7f2a7db1972fe46ee42d06af819b27297193ac89eb33a14292d8"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "pubsub-light",
+      "version": "1.12",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/pubsub-light/1.12/pubsub-light-1.12.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "666cbc579d82849bef8d0396a57335c9994222e8b0ba52f07be76dab9fb56c40"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "scm-api",
+      "version": "2.2.7",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/scm-api/2.2.7/scm-api-2.2.7.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "9c550f85ad8570b9d777a3c9880188fb00e84cbdf5b3704977e1a3e3edc73a47"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "script-security",
+      "version": "1.46",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/script-security/1.46/script-security-1.46.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8b7fd476309e61402cd95657a51869b906c39f696adac02779222007b89fa969"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "sse-gateway",
+      "version": "1.15",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/sse-gateway/1.15/sse-gateway-1.15.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "56b19b7a48f646dc8269bae4aca41ec11f71756d618d302b1f8b9d688441850f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "ssh-agent",
+      "version": "1.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ssh-agent/1.16/ssh-agent-1.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "18bab0fdcf65cec220866abd5ca8df9541b1091e1a876d9acb3283c6a969c478"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "ssh-credentials",
+      "version": "1.14",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ssh-credentials/1.14/ssh-credentials-1.14.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f5fc11e306cd0fe0abb25ffcf40014d6bc3c31318e9d2d3309e965320dfdde34"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "structs",
+      "version": "1.14",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/structs/1.14/structs-1.14.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "43a27488fd58f95affdef0766570bbe705ac8c39fe11d3b38208282c21cac58b"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "token-macro",
+      "version": "2.5",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/token-macro/2.5/token-macro-2.5.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "c6575d030ef6e0b416dad38094355eed30e860ade38759ff0a76e2f588350e6b"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins",
+      "artifactId": "variant",
+      "version": "1.1",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/variant/1.1/variant-1.1.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "971893fb05da213631b8ea977a32a5d4953f1cb7ab6fbdec9020d503550275ff"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-aggregator",
+      "version": "2.5",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-aggregator/2.5/workflow-aggregator-2.5.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f5122377769a5e43ee4c2d88c720dd893054c3658fc4d29f21d362eabcaac86a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-api",
+      "version": "2.29",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-api/2.29/workflow-api-2.29.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "f4cc9ea93ff77f51e16173f1e0c3e3646e92f1467bbc47f08b4574b380a93b32"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-basic-steps",
+      "version": "2.6",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-basic-steps/2.6/workflow-basic-steps-2.6.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "ba6bc7f586b902ba6aacae571a8ae78916e7f3e106d8a7da14c348ea933f0016"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-cps",
+      "version": "2.54",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-cps/2.54/workflow-cps-2.54.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "8d23332a54d8a744bd15a47d2eecd022068b2d40b62bc51b6c8b4dfdaf48894e"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-cps-global-lib",
+      "version": "2.9",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-cps-global-lib/2.9/workflow-cps-global-lib-2.9.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "b5a141c4896be15e09d76fc5b60df3fe701e94d2c2d2015a99ca5147a78b09d1"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-durable-task-step",
+      "version": "2.21",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-durable-task-step/2.21/workflow-durable-task-step-2.21.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "ff94f25addaf21bf510b6553572045f701daf94537a0763e47fb0f8446d24d2f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-job",
+      "version": "2.25",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-job/2.25/workflow-job-2.25.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "0c8500f819f34e008d90292a691b4fb4638a911a7fa5f31a3cb7a427a97f3c9d"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-multibranch",
+      "version": "2.20",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-multibranch/2.20/workflow-multibranch-2.20.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "c32aee40afd0684fd64dc4b13ea292667e26a33552c29fe8a02f72d57c6d1e1a"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-scm-step",
+      "version": "2.6",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-scm-step/2.6/workflow-scm-step-2.6.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "a382864adaf0fc80d58243568157a1450028e6d0503a03b81111d4c4de8275d0"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-step-api",
+      "version": "2.16",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-step-api/2.16/workflow-step-api-2.16.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "d642a4099d49be3cac71270e52565a367348c7ed45cde4d9e32ed0624c78759f"
+      }
+    },
+    {
+      "groupId": "org.jenkins-ci.plugins.workflow",
+      "artifactId": "workflow-support",
+      "version": "2.20",
+      "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-support/2.20/workflow-support-2.20.hpi",
+      "checksum": {
+        "type": "sha256",
+        "signature": "72add03ae7bc3d66d5cc46b425c13891ef5ce7a3fee839de1ceded2d3978086f"
+      }
+    }
+  ],
+  "environments": {
+    "docker-cloud": {
+      "plugins": [
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "docker-java-api",
+          "version": "3.0.14",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/docker-java-api/3.0.14/docker-java-api-3.0.14.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "14a48f9092863c7680c939c3163d9539e3b66f8e277fbe4c0e26a68cc60c4ba0"
+          }
+        },
+        {
+          "groupId": "io.jenkins.docker",
+          "artifactId": "docker-plugin",
+          "version": "1.1.6-rc865.abf142391212",
+          "url": "https://repo.jenkins-ci.org/incrementals/io/jenkins/docker/docker-plugin/1.1.6-rc865.abf142391212/docker-plugin-1.1.6-rc865.abf142391212.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "0d4e1f98dded7d9850603c2d7f9951886816ab7f569bd2ca5a97af7cd7ae812e"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "ssh-slaves",
+          "version": "1.22",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ssh-slaves/1.22/ssh-slaves-1.22.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "4a8f37338cf1740fcff0fbd7474d7f9532e954ccc276eb89f11cf91c2ac273e1"
+          }
+        }
+      ]
+    },
+    "aws-ec2-cloud": {
+      "plugins": [
+        {
+          "groupId": "io.jenkins.plugins",
+          "artifactId": "artifact-manager-s3",
+          "version": "1.1",
+          "url": "https://repo.jenkins-ci.org/releases/io/jenkins/plugins/artifact-manager-s3/1.1/artifact-manager-s3-1.1.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "c3c3467272febe6f7c6954cc76a36f96df6c73f0aa49a4ce5e478baac1d5bf25"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "aws-credentials",
+          "version": "1.23",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/aws-credentials/1.23/aws-credentials-1.23.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "20fe4b5c1273aee66b28adb504ccd0fbb0b44e240b84bdc74ef7a38749ee726e"
+          }
+        },
+        {
+          "groupId": "io.jenkins.plugins",
+          "artifactId": "aws-global-configuration",
+          "version": "1.0",
+          "url": "https://repo.jenkins-ci.org/releases/io/jenkins/plugins/aws-global-configuration/1.0/aws-global-configuration-1.0.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "ec03800c870e40de92a42c5e397e5988ddf564e8fd499d77d0eec6d2c575a4f9"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "aws-java-sdk",
+          "version": "1.11.341",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/aws-java-sdk/1.11.341/aws-java-sdk-1.11.341.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "ebe7cca7755dc020d138ef537a7bf7b61e3bbad41f7f0f6be4004917c0769238"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "ec2",
+          "version": "1.39",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/ec2/1.39/ec2-1.39.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "fdd8670b1a71bcdacc5d7a358fa67fb8c44efc6f2ecc717d5e572c669934a0a7"
+          }
+        },
+        {
+          "groupId": "org.jenkins-ci.plugins",
+          "artifactId": "node-iterator-api",
+          "version": "1.5",
+          "url": "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/node-iterator-api/1.5/node-iterator-api-1.5.hpi",
+          "checksum": {
+            "type": "sha256",
+            "signature": "ea5a5294fcccad5a26a7004edcb1e256bc2976fa68993ac17570370337f4d34a"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/distribution/tests/tests.sh
+++ b/distribution/tests/tests.sh
@@ -19,6 +19,8 @@ oneTimeSetUp() {
   # shellcheck disable=SC2119
   upload_update_level
 
+  # (parameter for ingest file name *is* optional)
+  # shellcheck disable=SC2119
   wait_for_jenkins
   # shellcheck disable=SC2016
   JENKINS_HOME="$( docker exec "$container_under_test" bash -c 'echo $JENKINS_HOME' )"

--- a/distribution/tests/utilities
+++ b/distribution/tests/utilities
@@ -104,6 +104,14 @@ wait_for_jenkins() {
   echo "Running containers (beware, ideally there should be none to avoid issues)"
   determine_container_name
 
+  if [[ -n $1 ]]; then
+    echo "Looking at docker logs since $1"
+    SINCE="--since=$1"
+  else
+    echo "Looking at docker logs from the beginning"
+    SINCE=""
+  fi
+
   # FIXME: have to wait pretty long because plugin installations
   # Possibly we'll want a special mode to accelerate testing, maybe by downloading plugins
   # from a local cache by overriding JENKINS_UC?
@@ -112,7 +120,7 @@ wait_for_jenkins() {
   while true
   do
     cur_attempts=$(( cur_attempts + 1 ))
-    if ( docker logs $container_under_test | grep "Jenkins is fully up and running" ); then
+    if ( docker logs $SINCE $container_under_test | grep "Jenkins is fully up and running" ); then
       info "Jenkins has started."
       break;
     elif (( $cur_attempts > $max_attempts )); then

--- a/distribution/tests/utilities
+++ b/distribution/tests/utilities
@@ -35,6 +35,7 @@ cleanup () {
   done
   docker cp "$container_under_test":/evergreen/data/jenkins/var/logs/evergreen.log.0 $testRunDirectory/evergreen.log.0
   docker cp "$container_under_test":/evergreen/data/updates.auditlog $testRunDirectory/updates.auditlog
+  docker cp "$container_under_test":/evergreen/supervisord.log $testRunDirectory/supervisord.log
   echo "Done getting logs for $containers"
 
   echo -n "Cleaning up... "


### PR DESCRIPTION
[JENKINS-54056](https://issues.jenkins-ci.org/browse/JENKINS-54056)

This PR implements the automated rollback for Update Levels.
If an UL is applied to a given instance, but that instance fails to start after application, it will taint it in the backend, then ask the backend again for a previous UL (most of the time, this would be the previous one).

This PR does **not** hande the data rollback part (aka JEP-302).
This part will be handled separately in a followup as of [JENKINS-54057](https://issues.jenkins-ci.org/browse/JENKINS-54057).