### PR TITLE
Make checkFileExists and touchFile sync

### DIFF
--- a/distribution/client/src/lib/storage.ts
+++ b/distribution/client/src/lib/storage.ts
@@ -77,11 +77,19 @@ export default class Storage {
     const pluginPath = this.pluginsDirectory();
     const retArray = [];
     plugins.forEach((plugin) => {
-      retArray.push(fs.unlink(`${pluginPath}/${plugin}.hpi`, () => {
-        logger.info(`${pluginPath}/${plugin}.hpi was deleted`);
-        UI.publish(`Deleted ${plugin}.hpi`);
+      retArray.push(new Promise((resolve, reject) => {
+
+        fs.unlink(`${pluginPath}/${plugin}.hpi`, (err) => {
+          if (err) {
+            reject(err);
+          }
+          logger.info(`${pluginPath}/${plugin}.hpi was deleted`);
+          UI.publish(`Deleted ${plugin}.hpi`);
+          resolve(true);
+        });
+
       }));
     });
-    return retArray;
+    return Promise.all(retArray);
   }
 }

--- a/distribution/client/test/storage.test.ts
+++ b/distribution/client/test/storage.test.ts
@@ -57,11 +57,11 @@ describe('The storage module', () => {
       mkdirp.sync(pluginPath);
       filenames.forEach((filename) => {
         h.touchFile(`${pluginPath}/${filename}.hpi`);
-        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).resolves.toBeTruthy();
+        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).toBeTruthy();
       });
       await Storage.removePlugins(filenames);
       filenames.forEach((filename) => {
-        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).resolves.toBeFalsy();
+        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).toBeFalsy();
       });
     });
   });

--- a/distribution/client/test/update.test.ts
+++ b/distribution/client/test/update.test.ts
@@ -1,5 +1,3 @@
-jest.mock('../src/lib/downloader');
-
 const fs            = require('fs');
 const feathers      = require('@feathersjs/feathers');
 const mkdirp        = require('mkdirp');
@@ -111,12 +109,14 @@ describe('The update module', () => {
     });
 
     it('should still update core if nothing else is passed in', async () => {
+      // Fake core with something much smaller, just to get a remote file (extension-filter is ~16kB)
       manifest.core = {
-        url: 'testurl',
-        checksum: { signature: 'signature' }
+        url: 'https://updates.jenkins-ci.org/download/plugins/extension-filter/1.0/extension-filter.hpi',
+        checksum: { signature: '9f82f97ad3f7625c03e15fbb7fc213eff23cc37535548383897670e0d6c7cf26' }
       };
       const response = await update.applyUpdates(manifest);
       expect(response).toBeTruthy();
+      expect(h.checkFileExists(`${Storage.jenkinsHome()}/jenkins.war`)).toBeTruthy();
       expect(update.updateInProgress).toBeFalsy();
     });
 
@@ -143,10 +143,6 @@ describe('The update module', () => {
 
     it ('should execute updates if passed in with no deletes', async () => {
       jest.setTimeout(10000);
-      (Downloader as unknown as jest.Mock).mockImplementationOnce(() => {
-        return require.requireActual('../src/lib/downloader').default();
-      });
-
       // daily-quote is only about 7k, good for simple download test
       manifest.plugins.updates = [
         {
@@ -160,14 +156,12 @@ describe('The update module', () => {
       let response = await update.applyUpdates(manifest);
       expect(response).toBeTruthy();
       expect(update.updateInProgress).toBeFalsy();
+      expect(h.checkFileExists(`${pluginPath}`)).toBeTruthy();
       expect(h.checkFileExists(`${pluginPath}/daily-quote.hpi`)).toBeTruthy();
       expect(restartCalled).toBeTruthy();
     });
 
     it('should execute both updates and deletes if both passed in', async () => {
-      (Downloader as unknown as jest.Mock).mockImplementationOnce(() => {
-        return require.requireActual('../src/lib/downloader').default();
-      });
       manifest.plugins.deletes = ['delete1'];
       // daily-quote is only about 7k, good for simple download test
       manifest.plugins.updates = [

--- a/distribution/client/test/update.test.ts
+++ b/distribution/client/test/update.test.ts
@@ -128,7 +128,7 @@ describe('The update module', () => {
 
       manifest.plugins.deletes.forEach((filename) => {
         h.touchFile(`${pluginPath}/${filename}.hpi`);
-        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).resolves.toBeTruthy();
+        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).toBeTruthy();
       });
 
       const response = await update.applyUpdates(manifest);
@@ -136,7 +136,7 @@ describe('The update module', () => {
       expect(update.updateInProgress).toBeFalsy();
 
       manifest.plugins.deletes.forEach((filename) => {
-        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).resolves.toBeFalsy();
+        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).toBeFalsy();
       });
       expect(restartCalled).toBeTruthy();
     });
@@ -160,7 +160,7 @@ describe('The update module', () => {
       let response = await update.applyUpdates(manifest);
       expect(response).toBeTruthy();
       expect(update.updateInProgress).toBeFalsy();
-      expect(h.checkFileExists(`${pluginPath}/daily-quote.hpi`)).resolves.toBeTruthy();
+      expect(h.checkFileExists(`${pluginPath}/daily-quote.hpi`)).toBeTruthy();
       expect(restartCalled).toBeTruthy();
     });
 
@@ -181,14 +181,14 @@ describe('The update module', () => {
       mkdirp.sync(pluginPath);
       manifest.plugins.deletes.forEach((filename) => {
         h.touchFile(`${pluginPath}/${filename}.hpi`);
-        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).resolves.toBeTruthy();
+        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).toBeTruthy();
       });
       let response = await update.applyUpdates(manifest);
       expect(response).toBeTruthy();
       expect(update.updateInProgress).toBeFalsy();
-      expect(h.checkFileExists(`${pluginPath}/daily-quote.hpi`)).resolves.toBeTruthy();
+      expect(h.checkFileExists(`${pluginPath}/daily-quote.hpi`)).toBeTruthy();
       manifest.plugins.deletes.forEach((filename) => {
-        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).resolves.toBeFalsy();
+        expect(h.checkFileExists(`${pluginPath}/${filename}.hpi`)).toBeFalsy();
       });
     });
   });

--- a/distribution/client/testlib/helpers.ts
+++ b/distribution/client/testlib/helpers.ts
@@ -2,24 +2,18 @@
  * This module contains functions which are helpful for running across multiple
  * tests
  */
-const fs = require('fs');
-const { promisify } = require('util');
-const open = promisify(fs.open);
-const close = promisify(fs.close);
-const access = promisify(fs.access);
+import fs from 'fs';
 
 export class Helpers {
   constructor () {
   }
 
   checkFileExists(filename) {
-    return access(filename, fs.F_OK, () => {
-      return false;
-    });
+    return fs.existsSync(filename);
   }
 
   touchFile(filename) {
-    return open(filename, 'w').then(close);
+    return fs.closeSync(fs.openSync(filename, 'w'));
   }
 }
 


### PR DESCRIPTION
Main goal here was to convert Helper.checkFileExists and Helper.touchFile from async to sync functions.
I think it's much easier for testing purposes, and is OK since this class is only used on testing side.

More importantly, the async->sync conversion showed a few issues in tests that weren't actually working. (As written in the chat, I'm almost 100% sure the `removePlugins` does work given the testing I did recently for rollback, where I had a case where a plugin was removed and crashed the instance. So _only_ the test was wrong, not the main _prod_ code).