### PR TITLE
[JENKINS-54204] Make sure to use the correct dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ update-package-locks:
 	# https://npm.community/t/some-packages-have-dist-tarball-as-http-and-not-https/285/13
 	rm -rf services/node_modules/ services/package-lock.json && \
 	rm -rf distribution/client/node_modules/ distribution/client/package-lock.json && \
-	cd services/ &&	$(NODE) npm install && \
+	cd services/ &&	$(NODE) npm ci && \
 	sed -i 's/"resolved": "http:/"resolved": "https:/g' package-lock.json && \
-	cd ../distribution/client && $(NODE) npm install && \
+	cd ../distribution/client && $(NODE) npm ci && \
 	sed -i 's/"resolved": "http:/"resolved": "https:/g' package-lock.json
 
 npm-audit-fix:

--- a/distribution/Makefile
+++ b/distribution/Makefile
@@ -46,7 +46,7 @@ prepare-distribution: build/jenkins-support build/jenkins.sh
 
 	# Once the tree has been put into place, node_modules must be generated for
 	# the distribution
-	(cd $(DIST_DIR)/client && $(ROOT_DIR)/tools/npm install --production)
+	(cd $(DIST_DIR)/client && $(ROOT_DIR)/tools/npm ci --production)
 
 prepare-docker-cloud-distribution: prepare-distribution
 	mkdir -p build/evergreen-docker-cloud/evergreen

--- a/node.mk
+++ b/node.mk
@@ -24,7 +24,7 @@ depends: node_modules
 node_modules: package-lock.json package.json
 	# Checking to see if the directory exists because npm install updates the
 	# directory every time it runs, busting the GNU/Make cache causing rebuilds
-	if [ ! -d node_modules ]; then $(NODE) npm install; fi;
+	if [ ! -d node_modules ]; then $(NODE) npm ci; fi;
 
 clean::
 	rm -rf vendor node_modules build

--- a/services/Dockerfile
+++ b/services/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9 as builder
+FROM node:10 as builder
 
 ARG APP_DIR=/srv/evergreen
 WORKDIR ${APP_DIR}

--- a/services/Dockerfile
+++ b/services/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR ${APP_DIR}
 
 ADD package*json ${APP_DIR}/
 
-RUN npm install
+RUN npm ci
 
 # Doing a multi-stage build to reset some stuff for a smaller image
 FROM node:9-alpine

--- a/services/Makefile
+++ b/services/Makefile
@@ -13,7 +13,7 @@ all: check docs container
 # directory every time it runs, busting the GNU/Make cache causing rebuilds
 depends: package.json
 	@if [ ! -d node_modules ]; then \
-		npm install; \
+		npm ci; \
 	fi;
 
 docs: depends


### PR DESCRIPTION
It can happen with `npm install` that we have new / different dependencies installed, which could be seen as `package-lock.json` is modified. Using `npm ci` rather than `npm install` make sure this doesn't happen.