### PR TITLE
[JENKINS-54454] Restart AWS evergreen container on host restart

### DIFF
--- a/distribution/environments/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/environments/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -62,6 +62,7 @@
               "sudo docker pull $DOCKER_IMAGE\n",
               "sudo docker run -d -p 8080:8080 -p 50000:50000 ",
               " --name evergreen",
+              " --restart=always",
               " -v jenkins-evergreen-data:/evergreen/data",
               " -v $PWD/ssh-agents-private-key:/run/secrets/PRIVATE_KEY:ro",
               " -e ARTIFACT_MANAGER_S3_BUCKET_NAME=", {"Ref":"S3BucketForArtifactManager"},


### PR DESCRIPTION
[JENKINS-54454](https://issues.jenkins-ci.org/browse/JENKINS-54454)

Align the AWS flavor with the official docs https://jenkins.io/projects/evergreen/ and have the Docker container restarted when the VM/host is restarted.

Reported by @imod thanks!