### PR TITLE
[JENKINS-54266] Update to latest EC2 plugin

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -148,7 +148,7 @@ spec:
       plugins:
         - groupId: org.jenkins-ci.plugins
           artifactId: ec2
-          version: 1.42-rc794.42645bb2b178
+          version: 1.42-rc815.d719dcecf165
         - groupId: io.jenkins.plugins
           artifactId: aws-global-configuration
           version: '1.0'
@@ -484,7 +484,7 @@ status:
           version: 1.11.403
         - groupId: org.jenkins-ci.plugins
           artifactId: ec2
-          version: 1.42-rc794.42645bb2b178
+          version: 1.42-rc815.d719dcecf165
         - groupId: org.jenkins-ci.plugins
           artifactId: node-iterator-api
           version: 1.5.0


### PR DESCRIPTION
[JENKINS-54266](https://issues.jenkins-ci.org/browse/JENKINS-54266)

Update to version fixing the exception during provisioning:

```
Oct 26, 2018 8:58:29 AM WARNING hudson.plugins.ec2.EC2Cloud provisionSlaveTemplate{ami='ami-06870ca4fe1151af2', labels='agent'}. Exception during provisioning
com.amazonaws.services.ec2.model.AmazonEC2Exception: Tag value cannot be null. Use empty string instead. (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterValue; Request ID: 72b4d323-8867-40c3-9c96-638297b6b3b0)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1658)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1322)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1072)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:745)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:719)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:701)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:669)
...
```