### PR TITLE
Revert to JCasC 1.1 to avoid dozens of warnings for core classes

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -8,7 +8,7 @@ spec:
   plugins:
     - groupId: io.jenkins
       artifactId: configuration-as-code
-      version: '1.3'
+      version: '1.1'
     - groupId: io.jenkins.plugins
       artifactId: evergreen
       version: 1.0-rc63.e2bbb0e347b6
@@ -257,7 +257,7 @@ status:
       version: 3.4.1
     - groupId: io.jenkins
       artifactId: configuration-as-code
-      version: '1.3'
+      version: '1.1'
     - groupId: org.jenkins-ci.plugins
       artifactId: credentials
       version: 2.1.18


### PR DESCRIPTION
Temporary while at least the core warnings are being fixed.
We should probably add tests to check the number of warnings generated in the json file parsed by the evergreen-client and sent to the Error Telemetry backend.

Manually tested on my own instance that going back to a previous version of CasC my Pipeline still runs successfully like before.

Rolling back to the state before https://github.com/jenkinsci/configuration-as-code-plugin/pull/587 while core warnings are being fixed.