### PR TITLE
JENKINS-54633 install evergreen in a dedicated VPC

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -90,7 +90,7 @@
       "Properties": {
           "DestinationCidrBlock" : "0.0.0.0/0",
           "GatewayId": { "Ref" : "EvergreenInternetGateway" },
-          "RouteTableId": { "Ref" : "EvergreenRouteTable" },
+          "RouteTableId": { "Ref" : "EvergreenRouteTable" }
       }
       },
       "EvergreenSubnetRouteTableAssociation": {

--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -22,9 +22,105 @@
       "MaxLength": "18",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
-    }
+    },
+    "VPCIPRange": {
+      "Description": "The private IP address range for allocating IPs within the VPC.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "10.0.0.0/16",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form x.x.x.x/x."
+    }      
   },
   "Resources": {
+
+      "EvergreenVPC": {
+          "Type": "AWS::EC2::VPC",
+          "Properties": {
+              "EnableDnsSupport": "true",
+              "EnableDnsHostnames": "true",
+              "CidrBlock": {"Ref": "VPCIPRange"},
+              "InstanceTenancy": "default",
+              "Tags": [
+                  { "Key": "Application", "Value": {"Ref": "AWS::StackId"}},
+                  { "Key": "Name", "Value" : "VPC for Jenkins"}
+              ]
+          }
+      },
+      "EvergreenInternetGateway": {
+          "Type": "AWS::EC2::InternetGateway",
+          "Properties": {
+              "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "Jenkins ${AWS::StackName}"}}
+              ]
+          }
+      },
+      "EvergreenGatewayAttachment": {
+          "Type": "AWS::EC2::VPCGatewayAttachment",
+          "Properties" : {
+              "VpcId" : { "Ref" : "EvergreenVPC" },
+              "InternetGatewayId": { "Ref" : "EvergreenInternetGateway" }
+          }      
+      },    
+      "EvergreenSubnet": {
+          "Type" : "AWS::EC2::Subnet",
+          "Properties": {
+              "AvailabilityZone" : "us-east-1a",
+              "VpcId": { "Ref" : "EvergreenVPC" },
+              "CidrBlock" : {"Ref": "VPCIPRange"},
+              "MapPublicIpOnLaunch": "true",
+              "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "Subnet for Jenkins ${AWS::StackName}"}}
+              ]           
+          }
+      },
+      "EvergreenRouteTable": {
+          "Type": "AWS::EC2::RouteTable",
+          "Properties": {
+              "VpcId" : { "Ref" : "EvergreenVPC" },
+              "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "RouteTable for Jenkins ${AWS::StackName}"}}
+              ]            
+          }
+      },
+      "EvergreenInternetRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "EvergreenGatewayAttachment",
+      "Properties": {
+          "DestinationCidrBlock" : "0.0.0.0/0",
+          "GatewayId": { "Ref" : "EvergreenInternetGateway" },
+          "RouteTableId": { "Ref" : "EvergreenRouteTable" },
+      }
+      },
+      "EvergreenSubnetRouteTableAssociation": {
+          "Type": "AWS::EC2::SubnetRouteTableAssociation",
+          "Properties": {
+              "RouteTableId": { "Ref" : "EvergreenRouteTable" },
+              "SubnetId": { "Ref" : "EvergreenSubnet" }
+          }
+      },     
+      "EvergreenSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+          "VpcId" : {"Ref" : "EvergreenVPC"},        
+          "GroupDescription" : "allow all traffic",
+          "SecurityGroupIngress" : [{
+              "IpProtocol": "-1",
+              "FromPort" : "-1",
+              "ToPort" : "-1",
+              "CidrIp" : "0.0.0.0/0"
+          }],
+          "SecurityGroupEgress" : [{
+              "IpProtocol" : "-1",
+              "CidrIp" : "0.0.0.0/0"
+          }],
+          "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "Global SecurityGroup for ${AWS::StackName}"}}
+          ]            
+      }
+  },
+
     "EC2EvergreenInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
@@ -40,7 +136,7 @@
           }
         ],
         "KeyName" : { "Ref" : "KeyNameParameter" },
-        "SecurityGroups": [
+        "SecurityGroupIds": [
           { "Ref": "EvergreenMasterSecurityGroup"}
         ],
         "Tags" : [
@@ -67,6 +163,7 @@
               " -v $PWD/ssh-agents-private-key:/run/secrets/PRIVATE_KEY:ro",
               " -e ARTIFACT_MANAGER_S3_BUCKET_NAME=", {"Ref":"S3BucketForArtifactManager"},
               " -e AGENT_SECURITY_GROUP=", {"Ref":"EvergreenAgentSecurityGroup"},
+              " -e AGENT_SUBNET=", {"Ref":"EvergreenSubnet"},
               " $DOCKER_IMAGE\n"
               ]
             ]

--- a/distribution/flavors/aws-ec2-cloud/README.adoc
+++ b/distribution/flavors/aws-ec2-cloud/README.adoc
@@ -41,7 +41,7 @@ aws cloudformation create-stack \
                    --template-body https://raw.githubusercontent.com/jenkins-infra/evergreen/master/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json \
                    --parameters \
                      ParameterKey=KeyNameParameter,ParameterValue=$PEM_NAME_IN_AWS \
-                     ParameterKey=SSHLocation,ParameterValue=$( curl ident.me )/0 \
+                     ParameterKey=SSHLocation,ParameterValue=$( curl v4.ident.me )/0 \
                      ParameterKey=PrivateKey,ParameterValue="$( cat $PEM_FILE_LOCAL_PATH )"
 
 This will display a json output like the following:

--- a/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
+++ b/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
@@ -14,6 +14,7 @@ jenkins:
             labelString: "agent"
             type: "T2Xlarge"
             securityGroups: "${AGENT_SECURITY_GROUP}"
+            subnetId: "${AGENT_SUBNET}"
             remoteFS: "/home/ec2-user"
             remoteAdmin: "ec2-user"
             initScript: >


### PR DESCRIPTION
[JENKINS-54633](https://issues.jenkins-ci.org/browse/JENKINS-54633)

Installing evergreen with cloudformation on AWS installs the whole thing in the default VPC. I think it would be better to isolate the build infrastructure in its own VPC.

This PR builds a new VPC on AWS and installs evergreen within