### PR TITLE
[JENKINS-54758] Redirect to embedded reverse proxy instead of Jenkins

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -60,7 +60,7 @@
               "echo \"", { "Ref": "PrivateKey"}, "\" > ssh-agents-private-key\n",
               "sudo docker volume create jenkins-evergreen-data\n",
               "sudo docker pull $DOCKER_IMAGE\n",
-              "sudo docker run -d -p 8080:8080 -p 50000:50000 ",
+              "sudo docker run -d -p 8080:80 -p 50000:50000 ",
               " --name evergreen",
               " --restart=always",
               " -v jenkins-evergreen-data:/evergreen/data",


### PR DESCRIPTION
[JENKINS-54758](https://issues.jenkins-ci.org/browse/JENKINS-54758)

We never refactored this since we added Nginx inside the image.
1) this means the UI when Jenkins is provisioning was not visible in AWS flavor
2) no embedded docs, and users can install plugins easily through the UI

Basically, this aligns the AWS flavor yet a bit more with the Docker-cloud flavor already officially documented on https://jenkins.io/projects/evergreen/