### PR TITLE
Raise build timeout for better trusted.ci accomodation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { label 'linux' }
 
     options {
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
         buildDiscarder(logRotator(daysToKeepStr: '10'))
         timestamps()
     }


### PR DESCRIPTION
Trusted.ci Jenkins infra behind the VPN can sometimes have many agents failed but still counting as used.
Given this infra is less visible and monitored than ci.jenkins.io, this can go unnoticed for quite some time.

In the current case, it could make Evergreen images publishing fail there because we reach the 1 hour timeout because all parallel branches are then run serially instead of in parallel (the build takes normally ~30 min on both ci.jenkins.io and trusted.ci as we could see a minute ago on a call with @olblak).

So I'm bumping this global build timeout so we're less sensitive to this potential infra issues.