### PR TITLE
[JENKINS-54598] Use fixed version of workflow-support for JDK11

### DIFF
--- a/services/cli/manifest-resolver.js
+++ b/services/cli/manifest-resolver.js
@@ -2,7 +2,7 @@
 
 const logger          = require('winston');
 const request         = require('request-promise');
-const compareVersions = require('compare-versions');
+const compareVersions = require('node-version-compare');
 
 const PluginManifest   = require('./plugin-manifest');
 const PluginDependency = require('./plugin-dependency');

--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -168,7 +168,7 @@ spec:
           version: 1.1.6-rc865.abf142391212
         - groupId: org.jenkins-ci.plugins.workflow
           artifactId: workflow-support
-          version: 2.21-rc591.43d37d4d080a
+          version: 2.23-rc674.73bb98187744
 status:
   core:
     version: '2.149'
@@ -507,3 +507,6 @@ status:
         - groupId: org.jenkins-ci.plugins
           artifactId: ssh-slaves
           version: '1.22'
+        - groupId: org.jenkins-ci.plugins.workflow
+          artifactId: workflow-support
+          version: 2.23-rc674.73bb98187744

--- a/services/package-lock.json
+++ b/services/package-lock.json
@@ -2529,12 +2529,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
-    "compare-versions": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg==",
-      "dev": true
-    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -4579,7 +4573,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4994,7 +4989,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5050,6 +5046,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5093,12 +5090,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8142,6 +8141,12 @@
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
       }
+    },
+    "node-version-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-version-compare/-/node-version-compare-1.0.1.tgz",
+      "integrity": "sha1-2Fv9IPCsreM1d/VmgscQnDTFUM0=",
+      "dev": true
     },
     "nodemon": {
       "version": "1.18.4",

--- a/services/package.json
+++ b/services/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@feathersjs/socketio-client": "^1.1.0",
     "cheerio": "^1.0.0-rc.2",
-    "compare-versions": "^3.4.0",
+    "node-version-compare": "^1.0.1",
     "eslint": "^4.19.1",
     "hoek": "^5.0.4",
     "jest": "^23.6.0",

--- a/services/prepare-essentials
+++ b/services/prepare-essentials
@@ -2,7 +2,7 @@
 
 const logger          = require('winston');
 const yargs           = require('yargs');
-const compareVersions = require('compare-versions')
+const compareVersions = require('node-version-compare');
 
 const Ingest           = require('./cli/ingest');
 const Manifest         = require('./cli/manifest');
@@ -22,12 +22,8 @@ yargs.command('propose-updates',
       if (updated == null) {
         logger.warn(`No such plugin ${plugin.artifactId}`);
       } else if (!plugin.version.match(/(.*?)-rc(\d+)\.(.*)?/)) {
-        try {
-          if (compareVersions(updated.version, plugin.version) == 1) {
-            logger.info(`The update center has a newer ${plugin.artifactId}: ${updated.version}`);
-          }
-        } catch (x) {
-          logger.warn(`Could not compare ${plugin.artifactId}:${plugin.version} to ${updated.version}: ${x}`);
+        if (compareVersions(updated.version, plugin.version) == 1) {
+          logger.info(`The update center has a newer ${plugin.artifactId}: ${updated.version}`);
         }
       }
     });


### PR DESCRIPTION
[JENKINS-54598](https://issues.jenkins-ci.org/browse/JENKINS-54598)

* First commit uses `node-version-compare` to avoid SEMVER errorscompare-versions does a strict SEMVER versions comparison, this does not work well, if at all, with Incremental releases for instance.
* second commit is the actual gist here, which was failing without the first commit, hence why they are together.