### PR TITLE
Remove trailing whitespace from links

### DIFF
--- a/distribution/client/public/502.html
+++ b/distribution/client/public/502.html
@@ -61,9 +61,7 @@
                     <p>
                         You may view the debug information using the
                         <strong>
-                            <a href="/evergreen/">
-                                Evergreen Status
-                            </a>
+                            <a href="/evergreen/">Evergreen Status</a>
                         </strong>
                         page.
                     </p>
@@ -72,17 +70,11 @@
             </main>
 
             <footer>
-                <a href="https://github.com/jenkins-infra/evergreen">
-                    Discuss on Gitter
-                </a>
+                <a href="https://github.com/jenkins-infra/evergreen">Discuss on Gitter</a>
                 &middot;
-                <a href="https://github.com/jenkins-infra/evergreen">
-                    Browse on GitHub
-                </a>
+                <a href="https://github.com/jenkins-infra/evergreen">Browse on GitHub</a>
                 &middot;
-                <a href="https://twitter.com/jenkinsci">
-                    Follow on Twitter
-                </a>
+                <a href="https://twitter.com/jenkinsci">Follow on Twitter</a>
             </footer>
         </div>
     </body>

--- a/distribution/client/public/521.html
+++ b/distribution/client/public/521.html
@@ -76,9 +76,7 @@
                     <p>
                         You may view the progress using the
                         <strong>
-                            <a href="/evergreen/">
-                                Evergreen Status
-                            </a>
+                            <a href="/evergreen/">Evergreen Status</a>
                         </strong>
                         page.
                     </p>
@@ -87,17 +85,11 @@
             </main>
 
             <footer>
-                <a href="https://github.com/jenkins-infra/evergreen">
-                    Discuss on Gitter
-                </a>
+                <a href="https://github.com/jenkins-infra/evergreen">Discuss on Gitter</a>
                 &middot;
-                <a href="https://github.com/jenkins-infra/evergreen">
-                    Browse on GitHub
-                </a>
+                <a href="https://github.com/jenkins-infra/evergreen">Browse on GitHub</a>
                 &middot;
-                <a href="https://twitter.com/jenkinsci">
-                    Follow on Twitter
-                </a>
+                <a href="https://twitter.com/jenkinsci">Follow on Twitter</a>
             </footer>
         </div>
     </body>


### PR DESCRIPTION
Whitespace collapses to a single character, not to 0...

For an example, see `Evergreen Status ` in:
![Trailing blue whitespace](https://jenkins.io/images/evergreen/evergreen-starting.png)