### PR TITLE
Update round of plugins

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -20,7 +20,7 @@ spec:
       version: 1.9.0
     - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-bitbucket-branch-source
-      version: 2.2.12
+      version: 2.2.15
     - groupId: org.jenkins-ci.plugins
       artifactId: config-file-provider
       version: 3.4.1
@@ -53,7 +53,7 @@ spec:
       version: 1.29.3
     - groupId: org.jenkins-ci.plugins
       artifactId: github-api
-      version: '1.92'
+      version: '1.95'
     - groupId: org.jenkins-ci.plugins
       artifactId: github-branch-source
       version: 2.4.1
@@ -80,7 +80,7 @@ spec:
       version: '2.6'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-api
-      version: '2.32'
+      version: '2.33'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps
       version: '2.60'
@@ -256,7 +256,7 @@ status:
       version: '2.9'
     - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-bitbucket-branch-source
-      version: 2.2.12
+      version: 2.2.15
     - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-folder
       version: '6.6'
@@ -307,7 +307,7 @@ status:
       version: 1.29.3
     - groupId: org.jenkins-ci.plugins
       artifactId: github-api
-      version: '1.92'
+      version: '1.95'
     - groupId: org.jenkins-ci.plugins
       artifactId: github-branch-source
       version: 2.4.1
@@ -436,7 +436,7 @@ status:
       version: '2.6'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-api
-      version: '2.32'
+      version: '2.33'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-basic-steps
       version: '2.11'


### PR DESCRIPTION
Only updated plugins already present under `spec`:

```
node ./prepare-essentials propose-updates --uc ./update-center.json
info: The update center has a newer branch-api: 2.1.1
info: The update center has a newer cloudbees-folder: 6.7
info: The update center has a newer configuration-as-code: 1.3
info: The update center has a newer display-url-api: 2.3.0
info: The update center has a newer durable-task: 1.28
warn: No such plugin essentials
warn: No such plugin evergreen
info: The update center has a newer pipeline-graph-analysis: 1.9
info: The update center has a newer pipeline-model-api: 1.3.3
info: The update center has a newer pipeline-model-definition: 1.3.3
info: The update center has a newer pipeline-model-extensions: 1.3.3
info: The update center has a newer pipeline-stage-tags-metadata: 1.3.3
info: The update center has a newer scm-api: 2.3.0
info: The update center has a newer workflow-basic-steps: 2.12
info: The update center has a newer workflow-durable-task-step: 2.26node ./prepare-essentials propose-updates --uc ./update-center.json
info: The update center has a newer branch-api: 2.1.1
info: The update center has a newer cloudbees-folder: 6.7
info: The update center has a newer configuration-as-code: 1.3
info: The update center has a newer display-url-api: 2.3.0
info: The update center has a newer durable-task: 1.28
warn: No such plugin essentials
warn: No such plugin evergreen
info: The update center has a newer pipeline-graph-analysis: 1.9
info: The update center has a newer pipeline-model-api: 1.3.3
info: The update center has a newer pipeline-model-definition: 1.3.3
info: The update center has a newer pipeline-model-extensions: 1.3.3
info: The update center has a newer pipeline-stage-tags-metadata: 1.3.3
info: The update center has a newer scm-api: 2.3.0
info: The update center has a newer workflow-basic-steps: 2.12
info: The update center has a newer workflow-durable-task-step: 2.26
```