### PR TITLE
Upgrade a number of other plugin dependencies

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -38,7 +38,7 @@ spec:
       version: 3.0.0-beta6-rc1776.912790760394
     - groupId: org.jenkins-ci.plugins
       artifactId: buildtriggerbadge
-      version: '2.9'
+      version: '2.10'
     - groupId: org.jenkins-ci.plugins
       artifactId: bouncycastle-api
       version: '2.17'
@@ -62,10 +62,10 @@ spec:
       version: '1.17'
     - groupId: org.jenkins-ci.plugins
       artifactId: jackson2-api
-      version: 2.9.7.1
+      version: 2.9.8
     - groupId: org.jenkins-ci.plugins
       artifactId: mailer
-      version: '1.22'
+      version: '1.23'
     - groupId: org.jenkins-ci.plugins
       artifactId: matrix-project
       version: '1.13'
@@ -104,7 +104,7 @@ spec:
       version: 4.0.2.3-rc229.d9b0eb3c576d
     - groupId: org.jenkins-ci.plugins
       artifactId: jdk-tool
-      version: '1.1'
+      version: '1.2'
     - groupId: org.jenkins-ci.plugins
       artifactId: authentication-tokens
       version: '1.3'
@@ -116,7 +116,7 @@ spec:
       version: 0.1.54.2
     - groupId: org.jenkins-ci.plugins
       artifactId: script-security
-      version: '1.48'
+      version: '1.49'
     - groupId: org.jenkins-ci.plugins
       artifactId: structs
       version: '1.17'
@@ -140,7 +140,7 @@ spec:
       version: 1.1.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-definition
-      version: 1.3.3
+      version: 1.3.4
   environments:
     - name: docker-cloud
       plugins:
@@ -256,7 +256,7 @@ status:
       version: 2.0.20
     - groupId: org.jenkins-ci.plugins
       artifactId: buildtriggerbadge
-      version: '2.9'
+      version: '2.10'
     - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-bitbucket-branch-source
       version: 2.2.15
@@ -328,10 +328,10 @@ status:
       version: 2.0.3
     - groupId: org.jenkins-ci.plugins
       artifactId: jackson2-api
-      version: 2.9.7.1
+      version: 2.9.8
     - groupId: org.jenkins-ci.plugins
       artifactId: jdk-tool
-      version: '1.1'
+      version: '1.2'
     - groupId: io.jenkins.blueocean
       artifactId: jenkins-design-language
       version: 1.10.1
@@ -352,7 +352,7 @@ status:
       version: '2.3'
     - groupId: org.jenkins-ci.plugins
       artifactId: mailer
-      version: '1.22'
+      version: '1.23'
     - groupId: org.jenkins-ci.plugins
       artifactId: matrix-project
       version: '1.13'
@@ -379,16 +379,16 @@ status:
       version: 1.3.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-api
-      version: 1.3.3
+      version: 1.3.4
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-declarative-agent
       version: 1.1.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-definition
-      version: 1.3.3
+      version: 1.3.4
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-extensions
-      version: 1.3.3
+      version: 1.3.4
     - groupId: org.jenkins-ci.plugins.pipeline-stage-view
       artifactId: pipeline-rest-api
       version: '2.10'
@@ -397,7 +397,7 @@ status:
       version: '2.3'
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-stage-tags-metadata
-      version: 1.3.3
+      version: 1.3.4
     - groupId: org.jenkins-ci.plugins.pipeline-stage-view
       artifactId: pipeline-stage-view
       version: '2.10'
@@ -415,7 +415,7 @@ status:
       version: 2.2.8
     - groupId: org.jenkins-ci.plugins
       artifactId: script-security
-      version: '1.48'
+      version: '1.49'
     - groupId: org.jenkins-ci.plugins
       artifactId: sse-gateway
       version: '1.16'


### PR DESCRIPTION
Perhaps most notable would be script-security, but generally this change is just
picking up some more recent updates.

There are still outstanding Pipeline related releases which need to be cut, but
those will come in their own pull request.