### PR TITLE
Upgrade to the latest available plugins in the Pipeline suite

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -187,9 +187,6 @@ spec:
         - groupId: io.jenkins.docker
           artifactId: docker-plugin
           version: 1.1.6-rc865.abf142391212
-        - groupId: org.jenkins-ci.plugins.workflow
-          artifactId: workflow-support
-          version: 2.23-rc674.73bb98187744
 status:
   core:
     version: '2.156'

--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -78,27 +78,45 @@ spec:
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-aggregator
       version: '2.6'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: durable-task
+      version: '1.28'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-api
       version: '2.33'
     - groupId: org.jenkins-ci.plugins.workflow
+      artifactId: workflow-basic-steps
+      version: '2.13'
+    - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps
-      version: '2.60'
+      version: '2.61'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps-global-lib
       version: '2.12'
     - groupId: org.jenkins-ci.plugins.workflow
+      artifactId: workflow-durable-task-step
+      version: '2.27'
+    - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-job
-      version: '2.29'
+      version: '2.31'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-scm-step
       version: '2.7'
     - groupId: org.jenkins-ci.plugins.workflow
+      artifactId: workflow-step-api
+      version: '2.17'
+    - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-support
-      version: '2.22'
+      version: '3.0'
     - groupId: org.jenkins-ci.plugins
       artifactId: pipeline-utility-steps
       version: 2.2.0
+    - groupId: org.jenkins-ci.plugins
+      artifactId: pipeline-graph-analysis
+      version: '1.9'
+    - groupId: org.jenkins-ci.plugins
+      artifactId: pipeline-input-step
+      version: '2.9'
     - groupId: org.jenkins-ci.plugins
       artifactId: metrics
       version: 4.0.2.3-rc229.d9b0eb3c576d
@@ -286,7 +304,7 @@ status:
       version: '1.17'
     - groupId: org.jenkins-ci.plugins
       artifactId: durable-task
-      version: '1.26'
+      version: '1.28'
     - groupId: io.jenkins.plugins
       artifactId: essentials
       version: 0.5.1
@@ -370,10 +388,10 @@ status:
       version: '2.7'
     - groupId: org.jenkins-ci.plugins
       artifactId: pipeline-graph-analysis
-      version: '1.7'
+      version: '1.9'
     - groupId: org.jenkins-ci.plugins
       artifactId: pipeline-input-step
-      version: '2.8'
+      version: '2.9'
     - groupId: org.jenkins-ci.plugins
       artifactId: pipeline-milestone-step
       version: 1.3.1
@@ -442,19 +460,19 @@ status:
       version: '2.33'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-basic-steps
-      version: '2.11'
+      version: '2.13'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps
-      version: '2.60'
+      version: '2.61'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps-global-lib
       version: '2.12'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-durable-task-step
-      version: '2.26'
+      version: '2.27'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-job
-      version: '2.29'
+      version: '2.31'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-multibranch
       version: '2.20'
@@ -463,10 +481,10 @@ status:
       version: '2.7'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-step-api
-      version: '2.16'
+      version: '2.17'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-support
-      version: '2.22'
+      version: '3.0'
   environments:
     - name: docker-cloud
       plugins:
@@ -510,6 +528,3 @@ status:
         - groupId: org.jenkins-ci.plugins
           artifactId: ssh-slaves
           version: '1.22'
-        - groupId: org.jenkins-ci.plugins.workflow
-          artifactId: workflow-support
-          version: 2.23-rc674.73bb98187744


### PR DESCRIPTION
While I'm still not sure what matrix of these plugins are _supposed_ to work
properly together. The latest from the Update Center might be okay :hankey:

:fire: **note**: this upgrades the `docker-cloud` flavor's version of `workflow-support` from an incremental build to the latest 3.0 :fire: 