### PR TITLE
Update to plugins fixed in security advisory 2019-01-08

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -89,7 +89,7 @@ spec:
       version: '2.13'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps
-      version: '2.61'
+      version: 2.61.1
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps-global-lib
       version: '2.12'
@@ -134,7 +134,7 @@ spec:
       version: 0.1.54.2
     - groupId: org.jenkins-ci.plugins
       artifactId: script-security
-      version: '1.49'
+      version: '1.50'
     - groupId: org.jenkins-ci.plugins
       artifactId: structs
       version: '1.17'
@@ -158,7 +158,7 @@ spec:
       version: 1.1.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-definition
-      version: 1.3.4
+      version: 1.3.4.1
   environments:
     - name: docker-cloud
       plugins:
@@ -394,16 +394,16 @@ status:
       version: 1.3.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-api
-      version: 1.3.4
+      version: 1.3.4.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-declarative-agent
       version: 1.1.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-definition
-      version: 1.3.4
+      version: 1.3.4.1
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-model-extensions
-      version: 1.3.4
+      version: 1.3.4.1
     - groupId: org.jenkins-ci.plugins.pipeline-stage-view
       artifactId: pipeline-rest-api
       version: '2.10'
@@ -412,7 +412,7 @@ status:
       version: '2.3'
     - groupId: org.jenkinsci.plugins
       artifactId: pipeline-stage-tags-metadata
-      version: 1.3.4
+      version: 1.3.4.1
     - groupId: org.jenkins-ci.plugins.pipeline-stage-view
       artifactId: pipeline-stage-view
       version: '2.10'
@@ -430,7 +430,7 @@ status:
       version: 2.2.8
     - groupId: org.jenkins-ci.plugins
       artifactId: script-security
-      version: '1.49'
+      version: '1.50'
     - groupId: org.jenkins-ci.plugins
       artifactId: sse-gateway
       version: '1.16'
@@ -460,7 +460,7 @@ status:
       version: '2.13'
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps
-      version: '2.61'
+      version: 2.61.1
     - groupId: org.jenkins-ci.plugins.workflow
       artifactId: workflow-cps-global-lib
       version: '2.12'


### PR DESCRIPTION
https://jenkins.io/security/advisory/2019-01-08/