### PR TITLE
Update cloudbees-bitbucket-branch-source & jsch plugins

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -20,7 +20,7 @@ spec:
       version: 1.10.1
     - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-bitbucket-branch-source
-      version: 2.2.15
+      version: 2.3.0
     - groupId: org.jenkins-ci.plugins
       artifactId: config-file-provider
       version: 3.4.1
@@ -131,7 +131,7 @@ spec:
       version: 2.0.3
     - groupId: org.jenkins-ci.plugins
       artifactId: jsch
-      version: 0.1.54.2
+      version: 0.1.55
     - groupId: org.jenkins-ci.plugins
       artifactId: script-security
       version: '1.50'
@@ -274,7 +274,7 @@ status:
       version: '2.10'
     - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-bitbucket-branch-source
-      version: 2.2.15
+      version: 2.3.0
     - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-folder
       version: '6.6'
@@ -358,7 +358,7 @@ status:
       version: 1.2.1
     - groupId: org.jenkins-ci.plugins
       artifactId: jsch
-      version: 0.1.54.2
+      version: 0.1.55
     - groupId: org.jenkins-ci.plugins
       artifactId: junit
       version: 1.26.1


### PR DESCRIPTION
More updates were showing up, but I updated only the ones that were already
under `spec`.

```
$ make propose-updates
node ./prepare-essentials propose-updates --uc ./update-center.json
info: The update center has a newer branch-api: 2.1.2
info: The update center has a newer cloudbees-bitbucket-branch-source: 2.3.0
info: The update center has a newer cloudbees-folder: 6.7
info: The update center has a newer display-url-api: 2.3.0
warn: No such plugin essentials
warn: No such plugin evergreen
info: The update center has a newer jsch: 0.1.55
info: The update center has a newer plain-credentials: 1.5
info: The update center has a newer scm-api: 2.3.0
info: The update center has a newer sse-gateway: 1.17
```

* @jvz @jeffret-b for the JSch update, if you think this is a risky, or not, update, I'm interested in your opinions.
* @casz interested also by your opinion/approval on the bitbucket-branch-source plugin. 

Thanks!