### PR TITLE
[JENKINS-54099] Update to sse-gateway:1.17

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -19,6 +19,9 @@ spec:
       artifactId: blueocean
       version: 1.10.1
     - groupId: org.jenkins-ci.plugins
+      artifactId: sse-gateway
+      version: '1.17'
+    - groupId: org.jenkins-ci.plugins
       artifactId: cloudbees-bitbucket-branch-source
       version: 2.3.0
     - groupId: org.jenkins-ci.plugins
@@ -433,7 +436,7 @@ status:
       version: '1.50'
     - groupId: org.jenkins-ci.plugins
       artifactId: sse-gateway
-      version: '1.16'
+      version: '1.17'
     - groupId: org.jenkins-ci.plugins
       artifactId: ssh-agent
       version: '1.17'


### PR DESCRIPTION
Bumping on Evergreen side already to anticipate https://github.com/jenkinsci/blueocean-plugin/pull/1900.

I looked at the code, and this looks pretty small, as also the biggest change is mine to silence this warning. (https://issues.jenkins-ci.org/browse/JENKINS-54099 fixed in https://github.com/jenkinsci/sse-gateway-plugin/pull/28). 