### PR TITLE
[JENKINS-55842] Exceptions should be sent to Sentry as messages

### DIFF
--- a/services/src/libs/sentry.js
+++ b/services/src/libs/sentry.js
@@ -83,11 +83,7 @@ class Sentry {
       },
     };
 
-    if (data.log.exception) {
-      this.raven.captureException(new Error(data.log.message), errorData);
-    } else {
-      this.raven.captureMessage(data.log.message, errorData);
-    }
+    this.raven.captureMessage(data.log.message, errorData);
   }
 }
 


### PR DESCRIPTION
[JENKINS-55842](https://issues.jenkins-ci.org/browse/JENKINS-55842)