### PR TITLE
Update to Jenkins 2.163

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations: null
 spec:
   core:
-    version: '2.162'
+    version: '2.163'
   plugins:
     - groupId: io.jenkins
       artifactId: configuration-as-code
@@ -192,7 +192,7 @@ spec:
           version: 1.1.6-rc865.abf142391212
 status:
   core:
-    version: '2.162'
+    version: '2.163'
   plugins:
     - groupId: org.jenkins-ci.ui
       artifactId: ace-editor


### PR DESCRIPTION
Also will be useful to support Java 11 runtime.

cc @jenkins-infra/java11-support 