### PR TITLE
Update to latest 2.164

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations: null
 spec:
   core:
-    version: '2.163'
+    version: '2.164'
   plugins:
     - groupId: io.jenkins
       artifactId: configuration-as-code
@@ -192,7 +192,7 @@ spec:
           version: 1.1.6-rc873.9fdb4e76a001
 status:
   core:
-    version: '2.163'
+    version: '2.164'
   plugins:
     - groupId: org.jenkins-ci.ui
       artifactId: ace-editor


### PR DESCRIPTION
To-do in general, but even more important these days so we can switch to a JDK11 in some not too distant future.

cc @jenkins-infra/java11-support