### PR TITLE
Support /jenkins and /evergreen (without final slash)

### DIFF
--- a/distribution/config/nginx.conf
+++ b/distribution/config/nginx.conf
@@ -143,11 +143,13 @@ http {
         # in case nginx is acting really bezerk.
         location /jenkins {
             proxy_set_header Host $host:$server_port;
+            rewrite /jenkins      /    break;
             rewrite /jenkins/(.*) /$1  break;
             proxy_pass http://jenkins;
         }
 
         location /evergreen {
+            rewrite /evergreen      /    break;
             rewrite /evergreen/(.*) /$1  break;
             proxy_pass http://evergreen;
         }


### PR DESCRIPTION
I'm not sure how I got there. I think clicking around in the /manage area of jenkins, but got:
```


NotFound: Page not found
    at new NotFound (/evergreen/client/node_modules/@feathersjs/errors/lib/index.js:114:17)
    at /evergreen/client/node_modules/@feathersjs/errors/lib/not-found-handler.js:7:10
    at Layer.handle [as handle_request] (/evergreen/client/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/evergreen/client/node_modules/express/lib/router/index.js:317:13)
    at /evergreen/client/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/evergreen/client/node_modules/express/lib/router/index.js:335:12)
    at next (/evergreen/client/node_modules/express/lib/router/index.js:275:10)
    at SendStream.error (/evergreen/client/node_modules/serve-static/index.js:121:7)
    at SendStream.emit (events.js:189:13)
    at SendStream.error (/evergreen/client/node_modules/send/index.js:270:17)
    at SendStream.onStatError (/evergreen/client/node_modules/send/index.js:421:12)
    at next (/evergreen/client/node_modules/send/index.js:736:16)
    at onstat (/evergreen/client/node_modules/send/index.js:725:14)
    at FSReqWrap.oncomplete (fs.js:153:21)
```

So quick update to nginx.

Warning: not really tested cause i was lazy and didn't rebuild the image.