### PR TITLE
Remove the disappeared remotingCLI configuration

### DIFF
--- a/distribution/config/as-code/casc.yaml
+++ b/distribution/config/as-code/casc.yaml
@@ -1,0 +1,8 @@
+---
+# Avoid hard errors on things which o not exist
+configuration-as-code:
+  version: 1
+  deprecated: warn
+  restricted: warn
+  unknown: warn
+

--- a/distribution/config/as-code/create-admin-user.yaml
+++ b/distribution/config/as-code/create-admin-user.yaml
@@ -16,6 +16,3 @@ jenkins:
   crumbIssuer:
     standard:
       excludeClientIPFromCrumb: false
-security:
-  remotingCLI:
-    enabled: false


### PR DESCRIPTION
In the latest weeklies, this configuration disappeared entirely and
Configuartion-as-Code users will experience hard-crashes on boot with this
configuration present.


The changes to how Configuration as Code is configured in this pull request does mean that we wouldn't see hard failures in CI for bad configuration @batmat , but I think it's worth the _potential_ to miss configuration errors.