### PR TITLE
Do not start multiple builds in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
         timeout(time: 4, unit: 'HOURS')
         buildDiscarder(logRotator(daysToKeepStr: '10'))
         timestamps()
+        disableConcurrentBuilds()
     }
 
     triggers {


### PR DESCRIPTION
If there's something wrong with executors, this just keeps adding new builds to the queue otherwise.
