### PR TITLE
Update to Jenkins 2.176

### DIFF
--- a/services/essentials.yaml
+++ b/services/essentials.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations: null
 spec:
   core:
-    version: '2.165'
+    version: '2.176'
   plugins:
     - groupId: io.jenkins
       artifactId: configuration-as-code
@@ -201,7 +201,7 @@ spec:
           version: 1.1.6-rc873.9fdb4e76a001
 status:
   core:
-    version: '2.165'
+    version: '2.176'
   plugins:
     - groupId: org.jenkins-ci.ui
       artifactId: ace-editor


### PR DESCRIPTION
Now https://github.com/jenkins-infra/evergreen/pull/408 was merged, let's close the gap.

I think we could, and should, then consider merging https://github.com/jenkins-infra/evergreen/pull/406.