### PR TITLE
Update CloudFormation to use the latest t3 and m5 instance types

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -3,7 +3,7 @@
   "Parameters" : {
     "InstanceTypeParameter" : {
       "Type" : "String",
-      "Default" : "t2.large",
+      "Default" : "t3.large",
       "AllowedValues" : ["t2.micro", "t3.micro", "m1.small", "m5.small", "m1.large", "m5.large", "t2.large", "t3.large"],
       "Description" : "Type of EC2 instance you want to run your master in."
     },

--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -4,7 +4,7 @@
     "InstanceTypeParameter" : {
       "Type" : "String",
       "Default" : "t2.large",
-      "AllowedValues" : ["t2.micro", "t3.micro", "m1.small", "m1.large", "t2.large", "t3.large"],
+      "AllowedValues" : ["t2.micro", "t3.micro", "m1.small", "m5.small", "m1.large", "m5.large", "t2.large", "t3.large"],
       "Description" : "Type of EC2 instance you want to run your master in."
     },
     "KeyNameParameter": {

--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -4,7 +4,7 @@
     "InstanceTypeParameter" : {
       "Type" : "String",
       "Default" : "t2.large",
-      "AllowedValues" : ["t2.micro", "m1.small", "m1.large", "t2.large"],
+      "AllowedValues" : ["t2.micro", "t3.micro", "m1.small", "m1.large", "t2.large", "t3.large"],
       "Description" : "Type of EC2 instance you want to run your master in."
     },
     "KeyNameParameter": {


### PR DESCRIPTION
Add support for t3 and m5 instance types
Change default from t2.large to t3.large

Closes #432