### PR TITLE
Parameterize the AMI and use the latest by default

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -31,6 +31,11 @@
       "Default": "10.0.0.0/16",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "must be a valid IP CIDR range of the form `x.x.x.x/x`."
+    },
+    "EvergreenImageId": {
+      "Description": "AMI to use for the EC2 Evergreen instance",
+      "Default": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
     }
   },
   "Resources": {
@@ -124,7 +129,7 @@
     "EC2EvergreenInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
-        "ImageId": "ami-cfe4b2b0",
+        "ImageId": {"Ref": "EvergreenImageId"},
         "InstanceType": {"Ref": "InstanceTypeParameter"},
         "IamInstanceProfile": {"Ref": "MasterInstanceProfile"},
         "BlockDeviceMappings": [


### PR DESCRIPTION
Adds a parameter for the AMI to use for the Evergreen instance
Use the latest AMI by default
By using a system parameter store parameter, the reference works across all regions which closes #431