### PR TITLE
JENKINS-54634 install evergreen in a dedicated VPC (fixed)

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -172,6 +172,18 @@
         }
       }
     },
+    "EC2EvergreenInstanceEIP": {
+        "DependsOn": [
+          "EvergreenVPC"
+        ],
+       "Type": "AWS::EC2::EIP",
+       "Properties": {
+       "Domain": "vpc",
+       "InstanceId" : {
+         "Ref" : "EC2EvergreenInstance"
+       }
+      }
+    },
     "EvergreenMasterSecurityGroup" : {
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
@@ -266,6 +278,17 @@
       },
       "S3BucketForArtifactManager": {
         "Type": "AWS::S3::Bucket"
+      }
+  },
+  "Outputs": {
+      "EC2EvergreenInstanceIP": {
+        "Description": "Public IP address of the Evergreen EC2 instance",
+        "Value": {
+          "Fn::GetAtt": [
+            "EC2EvergreenInstance",
+            "PublicIp"
+          ]
+        }
       }
   }
 }

--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -22,9 +22,105 @@
       "MaxLength": "18",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
       "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x"
+    },
+    "VPCIPRange": {
+      "Description": "The private IP address range for allocating IPs within the VPC.",
+      "Type": "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "Default": "10.0.0.0/16",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "must be a valid IP CIDR range of the form `x.x.x.x/x`."
     }
   },
   "Resources": {
+
+      "EvergreenVPC": {
+          "Type": "AWS::EC2::VPC",
+          "Properties": {
+              "EnableDnsSupport": true,
+              "EnableDnsHostnames": true,
+              "CidrBlock": {"Ref": "VPCIPRange"},
+              "InstanceTenancy": "default",
+              "Tags": [
+                  { "Key": "Application", "Value": {"Ref": "AWS::StackId"}},
+                  { "Key": "Name", "Value" : "VPC for Jenkins"}
+              ]
+          }
+      },
+      "EvergreenInternetGateway": {
+          "Type": "AWS::EC2::InternetGateway",
+          "Properties": {
+              "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "Jenkins ${AWS::StackName}"}}
+              ]
+          }
+      },
+      "EvergreenGatewayAttachment": {
+          "Type": "AWS::EC2::VPCGatewayAttachment",
+          "Properties" : {
+              "VpcId" : { "Ref" : "EvergreenVPC" },
+              "InternetGatewayId": { "Ref" : "EvergreenInternetGateway" }
+          }
+      },
+      "EvergreenSubnet": {
+          "Type" : "AWS::EC2::Subnet",
+          "Properties": {
+              "AvailabilityZone" : { "Fn::Select" : [ "0", { "Fn::GetAZs" : "" } ] },
+              "VpcId": { "Ref" : "EvergreenVPC" },
+              "CidrBlock" : {"Ref": "VPCIPRange"},
+              "MapPublicIpOnLaunch": true,
+              "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "Subnet for Jenkins ${AWS::StackName}"}}
+              ]
+          }
+      },
+      "EvergreenRouteTable": {
+          "Type": "AWS::EC2::RouteTable",
+          "Properties": {
+              "VpcId" : { "Ref" : "EvergreenVPC" },
+              "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "RouteTable for Jenkins ${AWS::StackName}"}}
+              ]
+          }
+      },
+      "EvergreenInternetRoute": {
+      "Type": "AWS::EC2::Route",
+      "DependsOn": "EvergreenGatewayAttachment",
+      "Properties": {
+          "DestinationCidrBlock" : "0.0.0.0/0",
+          "GatewayId": { "Ref" : "EvergreenInternetGateway" },
+          "RouteTableId": { "Ref" : "EvergreenRouteTable" }
+      }
+      },
+      "EvergreenSubnetRouteTableAssociation": {
+          "Type": "AWS::EC2::SubnetRouteTableAssociation",
+          "Properties": {
+              "RouteTableId": { "Ref" : "EvergreenRouteTable" },
+              "SubnetId": { "Ref" : "EvergreenSubnet" }
+          }
+      },
+      "EvergreenSecurityGroup" : {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties" : {
+          "VpcId" : {"Ref" : "EvergreenVPC"},
+          "GroupDescription" : "allow all traffic",
+          "SecurityGroupIngress" : [{
+              "IpProtocol": "-1",
+              "FromPort" : -1,
+              "ToPort" : -1,
+              "CidrIp" : "0.0.0.0/0"
+          }],
+          "SecurityGroupEgress" : [{
+              "IpProtocol" : "-1",
+              "CidrIp" : "0.0.0.0/0"
+          }],
+          "Tags": [
+                  { "Key": "Name", "Value" : {"Fn::Sub": "Global SecurityGroup for ${AWS::StackName}"}}
+          ]
+      }
+  },
+
     "EC2EvergreenInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
@@ -40,9 +136,10 @@
           }
         ],
         "KeyName" : { "Ref" : "KeyNameParameter" },
-        "SecurityGroups": [
+        "SecurityGroupIds": [
           { "Ref": "EvergreenMasterSecurityGroup"}
         ],
+        "SubnetId": { "Ref" : "EvergreenSubnet" },
         "Tags" : [
             {"Key" : "Name", "Value" : "Jenkins Evergreen Master"}
         ],
@@ -67,6 +164,7 @@
               " -v $PWD/ssh-agents-private-key:/run/secrets/PRIVATE_KEY:ro",
               " -e ARTIFACT_MANAGER_S3_BUCKET_NAME=", {"Ref":"S3BucketForArtifactManager"},
               " -e AGENT_SECURITY_GROUP=", {"Ref":"EvergreenAgentSecurityGroup"},
+              " -e AGENT_SUBNET=", {"Ref":"EvergreenSubnet"},
               " $DOCKER_IMAGE\n"
               ]
             ]
@@ -78,10 +176,11 @@
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
         "GroupDescription" : "Enable HTTP access via port 8080 and JNLP port (TODO: restrict agent port)",
+	"VpcId" : { "Ref":"EvergreenVPC"},
         "SecurityGroupIngress" : [
-          {"IpProtocol" : "tcp", "FromPort" : "22", "ToPort" : "22", "CidrIp" : { "Ref" : "SSHLocation"}},
-          {"IpProtocol" : "tcp", "FromPort" : "8080", "ToPort" : "8080", "CidrIp" : "0.0.0.0/0"},
-          {"IpProtocol" : "tcp", "FromPort" : "50000", "ToPort" : "50000", "CidrIp" : "0.0.0.0/0"}
+          {"IpProtocol" : "tcp", "FromPort" : 22, "ToPort" : 22, "CidrIp" : { "Ref" : "SSHLocation"}},
+          {"IpProtocol" : "tcp", "FromPort" : 8080, "ToPort" : 8080, "CidrIp" : "0.0.0.0/0"},
+          {"IpProtocol" : "tcp", "FromPort" : 50000, "ToPort" : 50000, "CidrIp" : "0.0.0.0/0"}
         ]
       }
     },
@@ -89,8 +188,9 @@
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
         "GroupDescription" : "Enable HTTP access via port 8080 and JNLP port (TODO: restrict agent port)",
+	"VpcId" : { "Ref":"EvergreenVPC"},
         "SecurityGroupIngress" : [
-          {"IpProtocol" : "tcp", "FromPort" : "22", "ToPort" : "22", "CidrIp" : "0.0.0.0/0"}
+          {"IpProtocol" : "tcp", "FromPort" : 22, "ToPort" : 22, "CidrIp" : "0.0.0.0/0"}
         ]
       }
     },

--- a/distribution/flavors/aws-ec2-cloud/README.adoc
+++ b/distribution/flavors/aws-ec2-cloud/README.adoc
@@ -54,70 +54,8 @@ This will display a json output like the following:
 After a few minutes, the Jenkins master will have been created as an EC2 instance. To retrieve its IP, use the following command:
 
 [source,shell]
-aws cloudformation list-stack-resources --region us-east-1 --stack-name $STACK_NAME
-
-This should display something like the following:
-
-[source,json]
-{
-    "StackResourceSummaries": [
-        {
-            "LogicalResourceId": "EC2EvergreenInstance",
-            "PhysicalResourceId": "i-09acbba4df83bcc59",
-            "ResourceType": "AWS::EC2::Instance",
-            "LastUpdatedTimestamp": "2018-07-16T05:23:36.996Z",
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated"
-        },
-        {
-            "LogicalResourceId": "EvergreenAgentSecurityGroup",
-            "PhysicalResourceId": "evergreen-test17793-EvergreenAgentSecurityGroup-2538QM8PAIPN",
-            "ResourceType": "AWS::EC2::SecurityGroup",
-            "LastUpdatedTimestamp": "2018-07-16T05:21:20.708Z",
-            "ResourceStatus": "CREATE_COMPLETE"
-        },
-        {
-            "LogicalResourceId": "EvergreenMasterRole",
-            "PhysicalResourceId": "evergreen-test17793-EvergreenMasterRole-120MK7UAUWEYO",
-            "ResourceType": "AWS::IAM::Role",
-            "LastUpdatedTimestamp": "2018-07-16T05:21:29.926Z",
-            "ResourceStatus": "CREATE_COMPLETE"
-        },
-        {
-            "LogicalResourceId": "EvergreenMasterSecurityGroup",
-            "PhysicalResourceId": "evergreen-test17793-EvergreenMasterSecurityGroup-L2O7JE3F1LLR",
-            "ResourceType": "AWS::EC2::SecurityGroup",
-            "LastUpdatedTimestamp": "2018-07-16T05:21:21.057Z",
-            "ResourceStatus": "CREATE_COMPLETE"
-        },
-        {
-            "LogicalResourceId": "MasterInstanceProfile",
-            "PhysicalResourceId": "evergreen-test17793-MasterInstanceProfile-9ZP9RP2YFF8",
-            "ResourceType": "AWS::IAM::InstanceProfile",
-            "LastUpdatedTimestamp": "2018-07-16T05:23:32.794Z",
-            "ResourceStatus": "CREATE_COMPLETE"
-        },
-        {
-            "LogicalResourceId": "S3BucketForArtifactManager",
-            "PhysicalResourceId": "evergreen-test17793-s3bucketforartifactmanager-hwdtoaezhx1c",
-            "ResourceType": "AWS::S3::Bucket",
-            "LastUpdatedTimestamp": "2018-07-16T05:21:40.019Z",
-            "ResourceStatus": "CREATE_COMPLETE"
-        }
-    ]
-}
-
-For the `EC2EvergreenInstance`, if the creation is complete enough, there will be also a `PhysicalResourceId`, here `i-09acbba4df83bcc59` in the example above.
-
-Use this to retrieve the instance IP address:
-
-[source,shell]
-aws ec2 describe-instances --region=us-east-1 --instance-ids <i-09acbba4df83bcc59> | \
-jq -r '.Reservations[0].Instances[].PublicIpAddress'
+aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='EC2EvergreenInstanceIP'].OutputValue" --output text
 1.2.3.4
-
-TIP: `jq` is a nice tool to process JSON.
-If you do not have it installed, either install it, or just look for `PublicIpAddress` field in the json returned from the `aws ec2 describe-instances` command.
 
 Once you have the public IP, after a few minutes
 footnote:[The master EC2 instance is being configured to run the Jenkins master. That is why even if the IP is already assigned, it could still take some more time to do additional things like installing Docker, pulling the evergreen image and have it started], open a browser on the http://1.2.3.4:8080 URL.

--- a/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
+++ b/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
@@ -14,6 +14,7 @@ jenkins:
             labelString: "agent"
             type: "T2Xlarge"
             securityGroups: "${AGENT_SECURITY_GROUP}"
+            subnetId: "${AGENT_SUBNET}"
             remoteFS: "/home/ec2-user"
             remoteAdmin: "ec2-user"
             initScript: >


### PR DESCRIPTION
Fixed problems in https://github.com/jenkins-infra/evergreen/pull/352
`EvergreenMasterSecurityGroup` and `EvergreenAgentSecurityGroup` did not have the `VpcId` property set (so they were being created in the default VPC)
`EC2EvergreenInstance` was missing the `SubnetId` property, so it was being created in the default VPC

All concerns expressed in https://github.com/jenkins-infra/evergreen/pull/396 have been addressed.

Also added an EIP so the IP address of the Evergreen instance doesn't change if the instance is recreated.