### PR TITLE
Specify the region to use in the Jenkins configuration

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -65,6 +65,7 @@
               " --restart=always",
               " -v jenkins-evergreen-data:/evergreen/data",
               " -v $PWD/ssh-agents-private-key:/run/secrets/PRIVATE_KEY:ro",
+              " -e REGION=", {"Ref":"AWS::Region"},
               " -e ARTIFACT_MANAGER_S3_BUCKET_NAME=", {"Ref":"S3BucketForArtifactManager"},
               " -e AGENT_SECURITY_GROUP=", {"Ref":"EvergreenAgentSecurityGroup"},
               " $DOCKER_IMAGE\n"

--- a/distribution/flavors/aws-ec2-cloud/config/as-code/artifact-manager-s3.yaml
+++ b/distribution/flavors/aws-ec2-cloud/config/as-code/artifact-manager-s3.yaml
@@ -6,8 +6,7 @@ unclassified:
           provider: s3
 aws:
   awsCredentials:
-    # FIXME: not a sensible default for everyone
-    region: "us-east-1"
+    region: "${REGION}"
   s3:
     # TODO: create through CloudFormation
     container: "${ARTIFACT_MANAGER_S3_BUCKET_NAME}"


### PR DESCRIPTION
Previously was hardcoded to us-east-1 so evergreen could only work in that region; this PR fixes that issue.

Closes #431