### PR TITLE
Recover the Evergreen instance if its instance health check fails for 5 minutes

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -166,6 +166,21 @@
       },
       "S3BucketForArtifactManager": {
         "Type": "AWS::S3::Bucket"
+      },
+      "EC2EvergreenInstanceAlarm": {
+        "Type": "AWS::CloudWatch::Alarm",
+        "Properties": {
+          "AlarmDescription": "Trigger a recovery when instance status check fails for 5 consecutive minutes.",
+          "Namespace": "AWS/EC2",
+          "MetricName": "StatusCheckFailed_System",
+          "Statistic": "Minimum",
+          "Period": 60,
+          "EvaluationPeriods": 5,
+          "ComparisonOperator": "GreaterThanThreshold",
+          "Threshold": 0,
+          "AlarmActions": [ {"Fn::Join" : ["", ["arn:aws:automate:", { "Ref" : "AWS::Region" }, ":ec2:recover" ]]} ],
+          "Dimensions": [{"Name": "InstanceId","Value": {"Ref": "EC2EvergreenInstance"}}]
+        }
       }
   }
 }


### PR DESCRIPTION
See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-recover.html