### PR TITLE
Specify the AMI and region for the Jenkins nodes

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
+++ b/distribution/flavors/aws-ec2-cloud/CloudFormation/cloudformation-template.json
@@ -36,6 +36,11 @@
       "Description": "AMI to use for the EC2 Evergreen instance",
       "Default": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+    },
+    "AgentImageId": {
+      "Description": "AMI to use for the EC2 agent instances",
+      "Default": "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
     }
   },
   "Resources": {
@@ -168,6 +173,7 @@
               " -v jenkins-evergreen-data:/evergreen/data",
               " -v $PWD/ssh-agents-private-key:/run/secrets/PRIVATE_KEY:ro",
               " -e REGION=", {"Ref":"AWS::Region"},
+              " -e AGENT_AMI=", {"Ref":"AgentImageId"},
               " -e ARTIFACT_MANAGER_S3_BUCKET_NAME=", {"Ref":"S3BucketForArtifactManager"},
               " -e AGENT_SECURITY_GROUP=", {"Ref":"EvergreenAgentSecurityGroup"},
               " -e AGENT_SUBNET=", {"Ref":"EvergreenSubnet"},

--- a/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
+++ b/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
@@ -8,9 +8,10 @@ jenkins:
         # already be used but let's be explicit to avoid issues.
         useInstanceProfileForCredentials: true
         privateKey: "${PRIVATE_KEY}"
+        region: "${REGION}"
         templates:
           - description: "EC2 Agent"
-            ami: "ami-cfe4b2b0"
+            ami: "${AGENT_AMI}"
             labelString: "agent"
             type: "T2Xlarge"
             securityGroups: "${AGENT_SECURITY_GROUP}"


### PR DESCRIPTION
The previous default values were an AMI that was in us-east-1 and the the us-east-1 region
which prevented this from working any other regions.

@mandie722 can you please take a look?