### PR TITLE
Install git on the EC2 agents

### DIFF
--- a/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
+++ b/distribution/flavors/aws-ec2-cloud/config/as-code/ec2-cloud.yaml
@@ -20,7 +20,7 @@ jenkins:
             initScript: >
               sudo yum update -y;
               sudo yum remove -y java-1.7.0-openjdk ;
-              sudo yum install -y docker java-1.8.0-openjdk-devel;
+              sudo yum install -y docker java-1.8.0-openjdk-devel git;
               sudo service docker start;
               sudo usermod -a -G docker ec2-user;
               sudo docker info;


### PR DESCRIPTION
The agents need git installed; otherwise, jobs fails during the "Check out from version control"

@mandie722 can you please take a look at this?